### PR TITLE
Fix bot API and env samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,8 @@ pip install -r requirements.txt
 #### Run the server
 
 ```bash
-python app.py
+python main.py
 ```
-
-> 💬 *Note: Make sure your main Python file is named `app.py`. If it has a different name, update the command accordingly.*
 
 ### ✅ Frontend (React)
 
@@ -62,6 +60,9 @@ npm start
 ```
 
 ## ⚙️ Environment variables
+
+Each service contains a `.env.example` file. Copy it to `.env` and adjust the
+values for your setup.
 
 ### Backend
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+MONGO_URI=mongodb://localhost:27017/creditdb
+PORT=5000
+BOT_URL=http://localhost:6000/api/bot/process
+AWS_REGION=us-east-1
+AWS_S3_BUCKET=your-bucket-name
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret

--- a/backend/routes/bot.js
+++ b/backend/routes/bot.js
@@ -6,7 +6,7 @@ const Customer = require('../models/Customer');
 const BOT_URL = process.env.BOT_URL || 'http://localhost:6000/api/bot/process';
 
 // Update status and optionally trigger bot
-router.put('/:id/status', async (req, res) => {
+const updateStatus = async (req, res) => {
   const { id } = req.params;
   const { status } = req.body;
 
@@ -28,7 +28,10 @@ router.put('/:id/status', async (req, res) => {
     console.error('Error updating status or sending to bot:', error);
     res.status(500).json({ error: error.message });
   }
-});
+};
+
+router.put('/:id/status', updateStatus);
+router.patch('/:id/status', updateStatus);
 
 // Endpoint for bot to send results
 router.post('/result', async (req, res) => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,6 +13,13 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// Basic env validation
+['MONGO_URI', 'BOT_URL'].forEach((key) => {
+  if (!process.env[key]) {
+    console.warn(`⚠️  Missing environment variable: ${key}`);
+  }
+});
+
 // MongoDB connection
 mongoose
   .connect(process.env.MONGO_URI)
@@ -30,6 +37,7 @@ const uploadRoutes = require('./routes/upload');
 const botRoutes = require('./routes/bot');
 
 app.use('/api/customers', customersRoutes);
+app.use('/api/clients', customersRoutes); // alias for convenience
 app.use('/api/upload', uploadRoutes);
 app.use('/api/bot', botRoutes);
 
@@ -38,4 +46,15 @@ app.use('/uploads', express.static('uploads'));
 
 app.get('/', (req, res) => {
   res.send('✅ Backend API is running!');
+});
+
+// 404 handler
+app.use((req, res, next) => {
+  res.status(404).json({ error: 'Not Found' });
+});
+
+// Error handler
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: err.message || 'Server error' });
 });

--- a/bot_service/.env.example
+++ b/bot_service/.env.example
@@ -1,0 +1,7 @@
+PORT=6000
+BACKEND_URL=http://localhost:5000
+AWS_REGION=us-east-1
+AWS_S3_BUCKET=your-bucket-name
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret
+OPENAI_API_KEY=your-openai-key


### PR DESCRIPTION
## Summary
- add backend and bot service .env examples
- validate env vars and improve error handling in backend
- expose `/api/clients` alias and PATCH status
- enhance bot service with dotenv, optional OpenAI support and pdfplumber parsing
- document env sample usage and update README

## Testing
- `npm test` *(fails: no test specified)*
- `python -m py_compile bot_service/main.py`

------
https://chatgpt.com/codex/tasks/task_e_687515e22888832e8972670045a55c0b