### PR TITLE
Add upload flow for credit reports

### DIFF
--- a/backend/routes/bot.js
+++ b/backend/routes/bot.js
@@ -14,19 +14,23 @@ const updateStatus = async (req, res) => {
     const customer = await Customer.findByIdAndUpdate(id, { status }, { new: true });
     if (!customer) return res.status(404).json({ error: 'Customer not found' });
 
-    if (status === 'In Progress') {
-      const payload = {
-        clientId: customer._id,
-        creditReportUrl: customer.creditReport,
-        instructions: { strategy: 'aggressive' },
-      };
-      try {
-        await axios.post(BOT_PROCESS_URL, payload);
-        console.log(`Sent to bot for customer ${customer.customerName}`);
-      } catch (err) {
-        console.error('Bot request failed:', err.message);
+      if (status === 'In Progress') {
+        const payload = {
+          clientId: customer._id,
+          creditReportUrl: customer.creditReport,
+          customerName: customer.customerName,
+          phone: customer.phone,
+          email: customer.email,
+          address: customer.address,
+          instructions: { strategy: 'aggressive' },
+        };
+        try {
+          await axios.post(BOT_PROCESS_URL, payload);
+          console.log(`Sent to bot for customer ${customer.customerName}`);
+        } catch (err) {
+          console.error('Bot request failed:', err.message);
+        }
       }
-    }
 
     res.json({ message: 'Status updated', customer });
   } catch (error) {


### PR DESCRIPTION
## Summary
- add full customer details when sending to the bot
- allow uploading a credit report from the customers table
- show success/failure notices and mark uploaded reports

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test -- --watchAll=false` in `credit-dashboard` *(fails to resolve react-router-dom)*

------
https://chatgpt.com/codex/tasks/task_e_6876ae7da858832eaa4c5a2947bf6de2