### PR TITLE
Improve report deletion and frontend text

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -74,7 +74,8 @@ router.delete('/:id', async (req, res) => {
       if (fs.existsSync(path)) fs.unlinkSync(path);
     }
 
-    customer.creditReport = undefined;
+    // Clear the creditReport field after deleting the file
+    customer.creditReport = null;
     await customer.save();
 
     res.json({ message: 'Credit report deleted' });

--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -158,7 +158,7 @@ export default function Customers() {
       .then(() => {
         setRows((prev) =>
           prev.map((row) =>
-            row.id === id ? { ...row, creditReport: '' } : row
+            row.id === id ? { ...row, creditReport: null } : row
           )
         );
         setSnackbar('Report deleted');
@@ -174,7 +174,7 @@ export default function Customers() {
     renderCell: (params) => {
       const url = params.value;
       if (!url) {
-        return <span style={{ color: 'red' }}>צריך להעלות ריפורט</span>;
+        return <span style={{ color: 'red' }}>Need to upload a report</span>;
       }
       const fullUrl = url.startsWith('http') ? url : `${BACKEND_URL}${url.startsWith('/') ? '' : '/'}` + url;
       return (


### PR DESCRIPTION
## Summary
- clear `creditReport` field when deleting a report
- show better placeholder text in the Customers page

## Testing
- `npm test --silent` in backend *(fails: Error: no test specified)*
- `CI=true npm test --silent` in `credit-dashboard` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_6876ba7ad39c832ea6209f1c3bf8e9cc