### PR TITLE
Improve PDF parsing fallback

### DIFF
--- a/backend/routes/bot.js
+++ b/backend/routes/bot.js
@@ -63,12 +63,18 @@ router.patch('/:id/status', updateStatus);
 // Endpoint for bot to send results
 router.post('/result', async (req, res) => {
   try {
-    const { clientId, letters } = req.body;
-    const update = { status: 'Letters Created', botStatus: 'done' };
-    if (letters) update.letters = letters;
+    const { clientId, letters, error } = req.body;
+    let update;
+    if (error) {
+      update = { botStatus: 'failed', botError: error };
+    } else {
+      update = { status: 'Letters Created', botStatus: 'done' };
+      if (letters) update.letters = letters;
+    }
+
     const customer = await Customer.findByIdAndUpdate(clientId, update, { new: true });
     if (!customer) return res.status(404).json({ error: 'Customer not found' });
-    console.log(`Set customer ${customer._id} botStatus to done`);
+    console.log(`Set customer ${customer._id} botStatus to ${update.botStatus}`);
     res.json({ message: 'Customer updated', customer });
   } catch (err) {
     console.error('Error saving bot results:', err);

--- a/bot_service/services/backend_comm.py
+++ b/bot_service/services/backend_comm.py
@@ -4,9 +4,11 @@ import requests
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:5000")
 
 
-def send_results(client_id: str, letters: list[dict]):
-    """Send generated letter data back to the backend."""
+def send_results(client_id: str, letters: list[dict], error: str | None = None):
+    """Send generated letter data or an error back to the backend."""
     payload = {"clientId": client_id, "letters": letters}
+    if error:
+        payload["error"] = error
     url = f"{BACKEND_URL}/api/bot/result"
     try:
         resp = requests.post(url, json=payload, timeout=10)


### PR DESCRIPTION
## Summary
- add fallback PDF text extraction using utils in bot service
- allow `send_results` to report errors
- return detailed bot processing error via backend API if needed

## Testing
- `npm test` *(fails: no test specified)*
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_6876c8990708832e8d1616e49964575b