### PR TITLE
Fix PDF extraction NoneType errors

### DIFF
--- a/bot_service/logic/utils.py
+++ b/bot_service/logic/utils.py
@@ -681,6 +681,10 @@ def convert_txts_to_pdfs(folder: Path):
 
 def extract_pdf_text_safe(pdf_path: Path, max_chars: int = 4000) -> str:
     """Extract text from a PDF using pdfplumber with a fitz fallback."""
+    if not pdf_path or not Path(pdf_path).exists():
+        print(f"[⚠️] Invalid PDF path: {pdf_path}")
+        return ""
+
     try:
         with pdfplumber.open(pdf_path) as pdf:
             parts = []


### PR DESCRIPTION
## Summary
- handle invalid PDF paths in `extract_pdf_text_safe`
- always capture fallback text and pass snippet to GPT

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6876dae136c4832eb1674a80e1c641f0