### PR TITLE
Handle None input in extract_pdf_text_safe

### DIFF
--- a/bot_service/logic/utils.py
+++ b/bot_service/logic/utils.py
@@ -679,14 +679,19 @@ def convert_txts_to_pdfs(folder: Path):
         print(f"[📄] Converted to PDF: {new_path}")
 
 
-def extract_pdf_text_safe(pdf_path: Path, max_chars: int = 4000) -> str:
+def extract_pdf_text_safe(pdf_path: Path | str | None, max_chars: int = 4000) -> str:
     """Extract text from a PDF using pdfplumber with a fitz fallback."""
-    if not pdf_path or not Path(pdf_path).exists():
+    if not pdf_path:
+        print(f"[⚠️] Invalid PDF path: {pdf_path}")
+        return ""
+
+    path = Path(pdf_path)
+    if not path.exists():
         print(f"[⚠️] Invalid PDF path: {pdf_path}")
         return ""
 
     try:
-        with pdfplumber.open(pdf_path) as pdf:
+        with pdfplumber.open(path) as pdf:
             parts = []
             for page in pdf.pages:
                 text = page.extract_text() or ""
@@ -701,7 +706,7 @@ def extract_pdf_text_safe(pdf_path: Path, max_chars: int = 4000) -> str:
         print(f"[⚠️] pdfplumber failed for {pdf_path}: {e}")
 
     try:
-        doc = fitz.open(pdf_path)
+        doc = fitz.open(path)
         text = ""
         for page in doc:
             text += page.get_text()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure project root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Provide dummy modules if missing
+if 'fpdf' not in sys.modules:
+    dummy_fpdf = types.ModuleType('fpdf')
+    dummy_fpdf.FPDF = object
+    sys.modules['fpdf'] = dummy_fpdf
+if 'fitz' not in sys.modules:
+    dummy_fitz = types.ModuleType('fitz')
+    sys.modules['fitz'] = dummy_fitz
+
+from bot_service.logic.utils import extract_pdf_text_safe
+
+
+def test_extract_pdf_text_safe_none():
+    assert extract_pdf_text_safe(None) == ""


### PR DESCRIPTION
## Summary
- support `None` for `extract_pdf_text_safe`
- adjust path handling in the function
- add regression test for calling the helper with `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e5191830832eb4fdc280eb9e1c96