### PR TITLE
Fix letter URL generation

### DIFF
--- a/bot_service/services/storage_service.py
+++ b/bot_service/services/storage_service.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import logging
 from pathlib import Path
+from config.settings import BACKEND_URL
 
 try:
     import boto3
@@ -47,4 +48,4 @@ def upload_file(local_path: str, key: str) -> str:
     dest_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(local_path, dest_path)
     logger.info("Saved %s locally at %s", key, dest_path)
-    return str(dest_path)
+    return f"{BACKEND_URL}/uploads/{key}"

--- a/credit-dashboard/src/pages/SendLetters.js
+++ b/credit-dashboard/src/pages/SendLetters.js
@@ -15,17 +15,16 @@ const columns = [
     flex: 1,
     renderCell: (params) => (
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-        {params.value.map((l, i) => (
-          <Button
-            key={i}
-            href={l.url}
-            target="_blank"
-            variant="outlined"
-            size="small"
-          >
-            {l.name || `Letter ${i + 1}`}
-          </Button>
-        ))}
+        {params.value.map((l, i) => {
+          const fullUrl = l.url.startsWith('http')
+            ? l.url
+            : `${BACKEND_URL}${l.url.startsWith('/') ? '' : '/'}${l.url}`;
+          return (
+            <Button key={i} href={fullUrl} target="_blank" variant="outlined" size="small">
+              {l.name || `Letter ${i + 1}`}
+            </Button>
+          );
+        })}
       </div>
     ),
   },


### PR DESCRIPTION
## Summary
- ensure local letter uploads return a URL accessible via the backend
- open letter links in the frontend using a full URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_6876f7ebed98832eac2c4551f7a40734