### PR TITLE
Centralize uploads under backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ values for your setup.
 
 ## 📂 Uploads structure
 
-Uploaded files are stored under the `uploads` folder when running locally.
+Uploaded files are stored under the `backend/uploads` folder when running
+locally so that both services reference the same directory.
 
-- Credit reports → `uploads/reports/<clientId>/`
-- Generated letters → `uploads/letters/<clientId>/`
+- Credit reports → `backend/uploads/reports/<clientId>/`
+- Generated letters → `backend/uploads/letters/<clientId>/`
 
 Folders are created automatically if they do not exist.
 

--- a/bot_service/services/storage_service.py
+++ b/bot_service/services/storage_service.py
@@ -14,7 +14,9 @@ except ImportError:  # Allow running without boto3 when not using S3
 BUCKET = os.getenv("AWS_S3_BUCKET")
 REGION = os.getenv("AWS_REGION", "us-east-1")
 
-LOCAL_UPLOAD_DIR = Path(__file__).resolve().parents[2] / "uploads"
+# Store files under the backend uploads directory so the Node backend can
+# serve them from the same location as credit reports.
+LOCAL_UPLOAD_DIR = Path(__file__).resolve().parents[2] / "backend" / "uploads"
 
 _s3_client = None
 if BUCKET and boto3:


### PR DESCRIPTION
## Summary
- store bot service files under `backend/uploads`
- document new unified path for uploaded files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687709757964832e8a55c46d950706a8