### PR TITLE
Add frontend bot flow controls

### DIFF
--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -166,6 +166,21 @@ export default function Customers() {
       .catch(() => setSnackbar('Delete failed'));
   };
 
+  const handleRunBot = (id) => {
+    fetch(`${BACKEND_URL}/api/bot/${id}/status`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'In Progress' }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        const updated = { ...data.customer, id: data.customer._id };
+        setRows((prev) => prev.map((row) => (row.id === id ? updated : row)));
+        setSnackbar('Bot started');
+      })
+      .catch(() => setSnackbar('Failed to start bot'));
+  };
+
   const creditReportColumn = {
     field: 'creditReport',
     headerName: 'Credit Report Link',
@@ -214,7 +229,7 @@ export default function Customers() {
     {
       field: 'actions',
       headerName: 'Actions',
-      width: 200,
+      width: 260,
       renderCell: (params) => (
         <div style={{ display: 'flex', gap: 8 }}>
           <Button
@@ -231,6 +246,14 @@ export default function Customers() {
             onClick={() => handleUploadClick(params.row.id)}
           >
             Upload Report
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => handleRunBot(params.row.id)}
+            disabled={!params.row.creditReport}
+          >
+            Run Bot
           </Button>
           <Button
             variant="outlined"

--- a/credit-dashboard/src/pages/SendLetters.js
+++ b/credit-dashboard/src/pages/SendLetters.js
@@ -29,16 +29,47 @@ const columns = [
     ),
   },
   { field: 'status', headerName: 'Status', width: 150 },
+  {
+    field: 'actions',
+    headerName: 'Actions',
+    width: 150,
+    renderCell: (params) => (
+      <Button
+        variant="outlined"
+        size="small"
+        onClick={() => params.row.onMark()}
+      >
+        Mark Completed
+      </Button>
+    ),
+  },
 ];
 
 export default function SendLetters() {
   const [rows, setRows] = React.useState([]);
 
+  const markCompleted = (id) => {
+    fetch(`${BACKEND_URL}/api/customers/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'Completed' }),
+    })
+      .then((res) => res.json())
+      .then(() => {
+        setRows((prev) => prev.filter((r) => r.id !== id));
+      })
+      .catch((err) => console.error(err));
+  };
+
   React.useEffect(() => {
     fetch(API_URL)
       .then((res) => res.json())
       .then((data) => {
-        const mapped = data.map((c) => ({ ...c, id: c.id || c._id }));
+        const mapped = data.map((c) => ({
+          ...c,
+          id: c.id || c._id,
+          onMark: () => markCompleted(c.id || c._id),
+        }));
         setRows(mapped);
       })
       .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- add a "Run Bot" button on the Customers table so staff can trigger bot processing
- add a handler that calls `/api/bot/:id/status` from the frontend
- show a "Mark Completed" button on the Send Letters table to close out clients
- mark customers completed via `/api/customers/:id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b8bf3070832e9467f3426bfb8b84