### PR TITLE
Update status after report upload

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -43,8 +43,16 @@ router.post('/:id', upload.single('file'), async (req, res) => {
       fs.unlinkSync(file.path);
     }
 
-    const customer = await Customer.findByIdAndUpdate(customerId, { creditReport: url });
+    const customer = await Customer.findById(customerId);
     if (!customer) return res.status(404).json({ error: 'Customer not found' });
+
+    customer.creditReport = url;
+
+    if (customer.status === 'Needs Updated Report') {
+      customer.status = 'Ready';
+    }
+
+    await customer.save();
 
     res.json({ message: 'File uploaded', url });
   } catch (err) {


### PR DESCRIPTION
## Summary
- reset customer status when uploading a new report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c13c71a4832ebc9e7640ce70b921