### PR TITLE
Implement full customer deletion with confirmation

### DIFF
--- a/backend/routes/customers.js
+++ b/backend/routes/customers.js
@@ -148,9 +148,14 @@ router.delete('/:id', async (req, res) => {
       }
     }
 
-    const lettersDir = path.join('uploads', 'letters', req.params.id);
+    const lettersDir = path.join(__dirname, '..', 'uploads', 'letters', req.params.id);
     if (fs.existsSync(lettersDir)) {
       fs.rmSync(lettersDir, { recursive: true, force: true });
+    }
+
+    const reportsDir = path.join(__dirname, '..', 'uploads', 'reports', req.params.id);
+    if (fs.existsSync(reportsDir)) {
+      fs.rmSync(reportsDir, { recursive: true, force: true });
     }
 
     await Customer.findByIdAndDelete(req.params.id);

--- a/credit-dashboard/src/components/ConfirmDialog.js
+++ b/credit-dashboard/src/components/ConfirmDialog.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+
+export default function ConfirmDialog({ open, onClose, onConfirm, title, message }) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <Typography>{message}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={onConfirm} color="error" variant="contained">
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -7,6 +7,7 @@ import Chip from '@mui/material/Chip';
 import Snackbar from '@mui/material/Snackbar';
 import { Link } from 'react-router-dom';
 import AddCustomerDialog from '../components/AddCustomerDialog';
+import ConfirmDialog from '../components/ConfirmDialog';
 
 const formColumns = [
   { field: 'customerName', headerName: 'Customer Name', width: 150, editable: true },
@@ -49,6 +50,7 @@ export default function Customers() {
   const [newCustomer, setNewCustomer] = React.useState({ status: 'New', roundNumber: 1 });
   const [snackbar, setSnackbar] = React.useState('');
   const [uploadId, setUploadId] = React.useState(null);
+  const [deleteId, setDeleteId] = React.useState(null);
   const fileInputRef = React.useRef();
 
   const BACKEND_URL = "http://localhost:5000";
@@ -144,16 +146,18 @@ export default function Customers() {
   };
 
   const handleDeleteCustomer = (id) => {
-    const confirmed = window.confirm(
-      'Are you sure you want to delete this customer? This action cannot be undone.'
-    );
-    if (!confirmed) return;
-    fetch(`${API_URL}/${id}`, { method: "DELETE" })
+    setDeleteId(id);
+  };
+
+  const confirmDeleteCustomer = () => {
+    if (!deleteId) return;
+    fetch(`${API_URL}/${deleteId}`, { method: "DELETE" })
       .then(res => res.json())
       .then(() => {
-        setRows((prev) => prev.filter((row) => row.id !== id));
+        setRows((prev) => prev.filter((row) => row.id !== deleteId));
         setSnackbar('Customer deleted');
-      });
+      })
+      .finally(() => setDeleteId(null));
   };
 
   const handleDeleteReport = (id) => {
@@ -315,6 +319,13 @@ export default function Customers() {
         ref={fileInputRef}
         style={{ display: 'none' }}
         onChange={handleFileChange}
+      />
+      <ConfirmDialog
+        open={Boolean(deleteId)}
+        onClose={() => setDeleteId(null)}
+        onConfirm={confirmDeleteCustomer}
+        title="Delete Customer"
+        message="Are you sure you want to permanently delete this customer and all their data? This action cannot be undone."
       />
     </Container>
   );


### PR DESCRIPTION
## Summary
- remove all customer data folders when deleting a customer on the backend
- add reusable React confirmation dialog component
- show confirmation modal before deleting a customer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c43c8d54832e8ae7252581d60ce5