### PR TITLE
Add testing mode integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ values for your setup.
 - `PORT` — port for the Node server (default 5000)
 - `BOT_PROCESS_URL` — bot endpoint for processing requests
 - `BOT_START_URL` — endpoint to start or ping the bot service
+- `APP_MODE` — "real" or "testing" to control how the bot generates letters
 - `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` — storage credentials
 
 ### Bot

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,7 @@ MONGO_URI=mongodb://localhost:27017/creditdb
 PORT=5000
 BOT_PROCESS_URL=http://localhost:6000/api/bot/process
 BOT_START_URL=http://localhost:6000/start
+APP_MODE=testing
 AWS_REGION=us-east-1
 AWS_S3_BUCKET=your-bucket-name
 AWS_ACCESS_KEY_ID=your-access-key

--- a/bot_service/README.md
+++ b/bot_service/README.md
@@ -19,4 +19,5 @@ Environment variables are read from a `.env` file or the environment:
 - `AWS_REGION`
 - `BACKEND_URL` (e.g. `http://localhost:5000`)
 - `PORT` (default 6000)
+- `APP_MODE` (optional) — default mode when no header/body value is provided
 


### PR DESCRIPTION
## Summary
- remove placeholder PDF generation from backend
- forward mode header and body to bot service
- set mode defaults via `APP_MODE`
- update cron jobs to send mode information
- add testing mode support in Python bot service
- document `APP_MODE`

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877daf2cd54832e833265499fb6b99e