### PR TITLE
Update bot pipeline with full letter generation

### DIFF
--- a/bot_service/main.py
+++ b/bot_service/main.py
@@ -1,14 +1,19 @@
 import os
 import tempfile
 import requests
-import pdfplumber
 from pathlib import Path
-from openai import OpenAI
 from flask import Flask, request, jsonify
 from reportlab.pdfgen import canvas
 from services.storage_service import upload_file
 from services.backend_comm import send_results
-from logic.utils import extract_pdf_text_safe
+from logic import (
+    analyze_report,
+    process_accounts,
+    letter_generator,
+    generate_goodwill_letters,
+    generate_custom_letters,
+    instructions_generator,
+)
 from config.settings import BOT_PORT
 from dotenv import load_dotenv
 import logging
@@ -17,8 +22,6 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(me
 logger = logging.getLogger(__name__)
 
 load_dotenv()
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
 
 app = Flask(__name__)
 
@@ -52,66 +55,54 @@ def process():
             report_path = f.name
         logger.info("Saved report to %s (%d bytes)", report_path, len(resp.content))
 
-        text = None
+        letters = []
         if mode == 'real':
-            # Parse a snippet of the report text so we can feed it to GPT
-            report_text = ""
             try:
-                logger.info("Parsing PDF with pdfplumber")
-                with pdfplumber.open(report_path) as pdf:
-                    logger.info("PDF opened, %d pages", len(pdf.pages))
-                    for page in pdf.pages:
-                        page_text = page.extract_text() or ""
-                        report_text += page_text
-                        if len(report_text) >= 1000:
-                            break
+                tmp_dir = Path(tempfile.mkdtemp())
+                analysis_path = tmp_dir / "analysis.json"
+                client_info = data.get("clientInfo", {}) or {}
+
+                logger.info("Analyzing full credit report")
+                analyze_report.analyze_credit_report(report_path, analysis_path, client_info)
+
+                bureau_data = process_accounts.process_analyzed_report(analysis_path)
+
+                letter_dir = tmp_dir / "letters"
+                is_id_theft = bool(client_info.get("is_identity_theft"))
+                letter_generator.generate_dispute_letters_for_all_bureaus(
+                    client_info,
+                    bureau_data,
+                    letter_dir,
+                    is_id_theft,
+                )
+                generate_goodwill_letters.generate_goodwill_letters(
+                    client_info, bureau_data, letter_dir
+                )
+                generate_custom_letters.generate_custom_letters(
+                    client_info, bureau_data, letter_dir
+                )
+                instructions_generator.generate_instruction_file(
+                    client_info, bureau_data, is_id_theft, letter_dir
+                )
+
+                for pdf in letter_dir.glob("*.pdf"):
+                    key = f"letters/{client_id}/{pdf.name}"
+                    url = upload_file(str(pdf), key)
+                    letters.append({"name": pdf.name, "url": url})
+
+                logger.info("Generated %d letters", len(letters))
             except Exception as e:
-                logger.warning("pdfplumber failed: %s", e)
-                report_text = extract_pdf_text_safe(Path(report_path), max_chars=1000)
-                logger.info("Fallback extracted %d characters", len(report_text))
+                logger.error("Full pipeline failed: %s", e)
 
-            if client:
-                try:
-                    logger.info("Calling OpenAI with %d character prompt", len(report_text))
-                    response = client.chat.completions.create(
-                        model="gpt-4o",
-                        messages=[
-                            {"role": "system", "content": "Write a credit dispute letter"},
-                            {
-                                "role": "user",
-                                "content": f"For client {client_id}. Here is the credit report snippet:\n{report_text[:1000]}",
-                            },
-                        ],
-                        max_tokens=200,
-                    )
-                    if (
-                        response.choices
-                        and response.choices[0].message
-                        and response.choices[0].message.content
-                    ):
-                        text = response.choices[0].message.content.strip()
-                        logger.info("Received OpenAI response (%d chars)", len(text))
-                except Exception as e:
-                    logger.error("OpenAI request failed: %s", e)
-        else:
-            text = f"Placeholder letter for {client_id}"
-
-        # Fallback text if no valid response
-        if not text or not isinstance(text, str):
+        if not letters:
             text = f"Dispute letter for {client_id}"
-            logger.info("Using fallback letter text")
-
-        # Create PDF with letter text
-        with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as f:
-            create_sample_letter(text, f.name)
-            letter_path = f.name
-        logger.info("Generated letter PDF at %s", letter_path)
-
-        # Upload letter into client-specific letters folder
-        key = f"letters/{client_id}/dispute_letter.pdf"
-        url = upload_file(letter_path, key)
-        logger.info("Uploaded letter to %s", url)
-        letters = [{'name': 'dispute_letter.pdf', 'url': url}]
+            with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as f:
+                create_sample_letter(text, f.name)
+                letter_path = f.name
+            logger.info("Generated fallback letter PDF at %s", letter_path)
+            key = f"letters/{client_id}/dispute_letter.pdf"
+            url = upload_file(letter_path, key)
+            letters = [{"name": "dispute_letter.pdf", "url": url}]
 
         send_results(client_id, letters)
         logger.info("Results sent to backend")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,101 @@
+import sys
+from pathlib import Path
+import types
+import os
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+BOT_DIR = ROOT / 'bot_service'
+if str(BOT_DIR) not in sys.path:
+    sys.path.insert(0, str(BOT_DIR))
+os.chdir(BOT_DIR)
+
+from flask import Flask
+import builtins
+
+import pytest
+
+# Dummy modules for optional deps
+if 'fpdf' not in sys.modules:
+    dummy_fpdf = types.ModuleType('fpdf')
+    dummy_fpdf.FPDF = object
+    sys.modules['fpdf'] = dummy_fpdf
+if 'fitz' not in sys.modules:
+    dummy_fitz = types.ModuleType('fitz')
+    sys.modules['fitz'] = dummy_fitz
+if 'pdfkit' not in sys.modules:
+    dummy_pdfkit = types.ModuleType('pdfkit')
+    dummy_pdfkit.configuration = lambda **kw: types.SimpleNamespace()
+    dummy_pdfkit.from_string = lambda *a, **k: None
+    sys.modules['pdfkit'] = dummy_pdfkit
+
+from bot_service import main as bot_main
+
+
+class DummyResp:
+    def __init__(self, content=b'pdf'):
+        self.content = content
+    def raise_for_status(self):
+        pass
+
+
+def create_pdf(path: Path):
+    from reportlab.pdfgen import canvas
+    c = canvas.Canvas(str(path))
+    c.drawString(100, 750, "hello")
+    c.save()
+
+
+def test_process_testing_mode(monkeypatch, tmp_path):
+    pdf_file = tmp_path / 'sample.pdf'
+    create_pdf(pdf_file)
+    monkeypatch.setattr(bot_main.requests, 'get', lambda url, timeout=10: DummyResp(pdf_file.read_bytes()))
+
+    uploaded = {}
+    def fake_upload(local, key):
+        uploaded[key] = True
+        return f'url/{key}'
+    monkeypatch.setattr(bot_main, 'upload_file', fake_upload)
+
+    results = {}
+    def fake_send_results(cid, letters, error=None):
+        results['cid'] = cid
+        results['letters'] = letters
+        results['error'] = error
+    monkeypatch.setattr(bot_main, 'send_results', fake_send_results)
+
+    client = bot_main.app.test_client()
+    resp = client.post('/api/bot/process', json={'clientId': 'c1', 'creditReportUrl': 'http://x/test.pdf'}, headers={'X-App-Mode': 'testing'})
+    assert resp.status_code == 200
+    assert results['cid'] == 'c1'
+    assert results['letters']
+    assert results['letters'][0]['name'].endswith('.pdf')
+
+
+def test_process_real_mode_fallback(monkeypatch, tmp_path):
+    pdf_file = tmp_path / 'sample.pdf'
+    create_pdf(pdf_file)
+    monkeypatch.setattr(bot_main.requests, 'get', lambda url, timeout=10: DummyResp(pdf_file.read_bytes()))
+
+    monkeypatch.setattr(bot_main.analyze_report, 'analyze_credit_report', lambda *a, **k: (_ for _ in ()).throw(Exception('fail')))
+
+    uploaded = {}
+    def fake_upload(local, key):
+        uploaded[key] = True
+        return f'url/{key}'
+    monkeypatch.setattr(bot_main, 'upload_file', fake_upload)
+
+    results = {}
+    def fake_send_results(cid, letters, error=None):
+        results['cid'] = cid
+        results['letters'] = letters
+        results['error'] = error
+    monkeypatch.setattr(bot_main, 'send_results', fake_send_results)
+
+    client = bot_main.app.test_client()
+    resp = client.post('/api/bot/process', json={'clientId': 'c2', 'creditReportUrl': 'http://x/test.pdf'}, headers={'X-App-Mode': 'real'})
+    assert resp.status_code == 200
+    # Fallback should still produce a letter
+    assert results['letters']
+    assert any(l['name'].endswith('.pdf') for l in results['letters'])


### PR DESCRIPTION
## Summary
- rewrite `bot_service/main.py` to run the full analysis pipeline
- generate multiple letters and upload them before sending results
- add regression tests for the Flask endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877dff555a0832eb0ece1fe922eedff