### PR TITLE
Fix wkhtmltopdf path on Windows

### DIFF
--- a/bot_service/logic/generate_custom_letters.py
+++ b/bot_service/logic/generate_custom_letters.py
@@ -10,7 +10,14 @@ from logic.utils import gather_supporting_docs
 load_dotenv()
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf")
+# Use an explicit wkhtmltopdf path on Windows so PDF generation works
+# without requiring additional configuration.
+DEFAULT_WKHTMLTOPDF = (
+    r"C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe"
+    if os.name == "nt"
+    else "wkhtmltopdf"
+)
+WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", DEFAULT_WKHTMLTOPDF)
 pdf_config = pdfkit.configuration(wkhtmltopdf=WKHTMLTOPDF_PATH)
 
 env = Environment(loader=FileSystemLoader("templates"))

--- a/bot_service/logic/generate_goodwill_letters.py
+++ b/bot_service/logic/generate_goodwill_letters.py
@@ -19,7 +19,14 @@ from logic.utils import (
 load_dotenv()
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf")
+# Default wkhtmltopdf path works cross-platform. Windows installs typically
+# reside under "Program Files" so we explicitly reference that location.
+DEFAULT_WKHTMLTOPDF = (
+    r"C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe"
+    if os.name == "nt"
+    else "wkhtmltopdf"
+)
+WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", DEFAULT_WKHTMLTOPDF)
 pdf_config = pdfkit.configuration(wkhtmltopdf=WKHTMLTOPDF_PATH)
 
 template_env = Environment(loader=FileSystemLoader("templates"))

--- a/bot_service/logic/instructions_generator.py
+++ b/bot_service/logic/instructions_generator.py
@@ -18,6 +18,14 @@ load_dotenv()
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 env = Environment(loader=FileSystemLoader("templates"))
 
+# Explicit wkhtmltopdf path for Windows installations.
+DEFAULT_WKHTMLTOPDF = (
+    r"C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe"
+    if os.name == "nt"
+    else "wkhtmltopdf"
+)
+WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", DEFAULT_WKHTMLTOPDF)
+
 
 def get_logo_base64() -> str:
     """Return the Credit Impact logo encoded as a base64 data URI."""
@@ -39,7 +47,7 @@ def extract_clean_name(full_name: str) -> str:
     return " ".join(unique_parts)
 
 def render_html_to_pdf(html_string: str, output_path: Path):
-    config = pdfkit.configuration(wkhtmltopdf=os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf"))
+    config = pdfkit.configuration(wkhtmltopdf=WKHTMLTOPDF_PATH)
     options = {"quiet": ""}
     try:
         pdfkit.from_string(html_string, str(output_path), configuration=config, options=options)

--- a/bot_service/logic/letter_generator.py
+++ b/bot_service/logic/letter_generator.py
@@ -42,7 +42,14 @@ def dedupe_disputes(disputes: list[dict], bureau_name: str, log: list[str]) -> l
 
 load_dotenv()
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", "wkhtmltopdf")
+# Point to the wkhtmltopdf executable explicitly on Windows installs so
+# PDF generation functions without additional setup.
+DEFAULT_WKHTMLTOPDF = (
+    r"C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe"
+    if os.name == "nt"
+    else "wkhtmltopdf"
+)
+WKHTMLTOPDF_PATH = os.getenv("WKHTMLTOPDF_PATH", DEFAULT_WKHTMLTOPDF)
 
 CREDIT_BUREAU_ADDRESSES = {
     "Experian": "P.O. Box 4500, Allen, TX 75013",


### PR DESCRIPTION
## Summary
- make wkhtmltopdf default to the Windows installation path
- keep Unix compatibility by falling back to "wkhtmltopdf"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877e5765380832e926e851dfb0c17ff