### PR TITLE
Add dict helpers to Account dataclass

### DIFF
--- a/bot_service/logic/process_accounts.py
+++ b/bot_service/logic/process_accounts.py
@@ -63,6 +63,20 @@ class Account:
         else:
             self.extra[key] = value
 
+    def copy(self) -> Dict[str, Any]:
+        """Return a dictionary copy of this account."""
+        return self.to_dict().copy()
+
+    def items(self):
+        """Return an iterator over key/value pairs like ``dict.items()``."""
+        return self.to_dict().items()
+
+    def __iter__(self):
+        return iter(self.to_dict())
+
+    def __len__(self) -> int:
+        return len(self.to_dict())
+
 # 💡 Functions to enrich goodwill accounts with hardship context
 
 def infer_hardship_reason(account: Account) -> str:


### PR DESCRIPTION
## Summary
- expose `copy` and `items` on `Account`
- implement `__iter__` and `__len__` for full dict-like behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ebb74ce0832e9979875d1ff2a533