### PR TITLE
Improve dashboard table layouts

### DIFF
--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -16,7 +16,6 @@ const formColumns = [
   { field: 'email', headerName: 'Email', width: 180, editable: true },
   { field: 'address', headerName: 'Address', width: 180, editable: true },
   { field: 'startDate', headerName: 'Start Date', width: 130, editable: true },
-  { field: 'roundNumber', headerName: 'Round Number', width: 130, editable: true },
   { field: 'notes', headerName: 'Notes', width: 200, editable: true },
   {
     field: 'issueDetails',
@@ -238,8 +237,27 @@ export default function Customers() {
     {
       field: 'status',
       headerName: 'Status',
-      width: 120,
-      renderCell: (params) => <Chip label={params.value} color={params.value === 'Completed' ? 'success' : 'info'} />,
+      width: 250,
+      renderCell: (params) => {
+        const color =
+          params.row.status === 'Completed'
+            ? 'success'
+            : params.row.status === 'Needs Updated Report'
+            ? 'warning'
+            : 'info';
+        return (
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+            <Chip label={`Round ${params.row.roundNumber || 1}`} size="small" />
+            <Chip label={params.row.status} color={color} size="small" />
+            {params.row.status === 'Needs Updated Report' && (
+              <Chip label="Upload new report" color="warning" size="small" />
+            )}
+            {params.row.creditReport && (
+              <Chip label="Report uploaded" color="success" size="small" />
+            )}
+          </div>
+        );
+      },
       editable: true,
     },
     {
@@ -247,7 +265,7 @@ export default function Customers() {
       headerName: 'Actions',
       width: 320,
       renderCell: (params) => (
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
           <Button
             variant="outlined"
             size="small"
@@ -263,9 +281,6 @@ export default function Customers() {
           >
             Upload Report
           </Button>
-          {params.row.status === 'Needs Updated Report' && (
-            <Chip label="Upload new report" color="warning" size="small" />
-          )}
           <Button
             variant="outlined"
             size="small"
@@ -282,10 +297,6 @@ export default function Customers() {
           >
             Delete
           </Button>
-          {params.row.creditReport && (
-            <Chip label="Report uploaded" color="success" size="small" />
-          )}
-          <Chip label={`Round: ${params.row.roundNumber || 1}`} size="small" />
         </div>
       ),
     },

--- a/credit-dashboard/src/pages/SendLetters.js
+++ b/credit-dashboard/src/pages/SendLetters.js
@@ -3,19 +3,19 @@ import { DataGrid } from '@mui/x-data-grid';
 import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 
 const BACKEND_URL = 'http://localhost:5000';
 const API_URL = `${BACKEND_URL}/api/customers/letters-ready`;
 
 const columns = [
   { field: 'customerName', headerName: 'Customer Name', width: 180 },
-  { field: 'roundNumber', headerName: 'Round', width: 100 },
   {
     field: 'letters',
     headerName: 'Letters',
     flex: 1,
     renderCell: (params) => (
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+      <div style={{ display: 'flex', flexWrap: 'nowrap', gap: 8, overflowX: 'auto' }}>
         {params.value.map((l, i) => {
           const fullUrl = l.url.startsWith('http')
             ? l.url
@@ -29,7 +29,25 @@ const columns = [
       </div>
     ),
   },
-  { field: 'status', headerName: 'Status', width: 150 },
+  {
+    field: 'status',
+    headerName: 'Status',
+    width: 220,
+    renderCell: (params) => {
+      const color =
+        params.row.status === 'Completed'
+          ? 'success'
+          : params.row.status === 'Needs Updated Report'
+          ? 'warning'
+          : 'info';
+      return (
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+          <Chip label={`Round ${params.row.roundNumber || 1}`} size="small" />
+          <Chip label={params.row.status} color={color} size="small" />
+        </div>
+      );
+    },
+  },
   {
     field: 'actions',
     headerName: 'Actions',


### PR DESCRIPTION
## Summary
- remove `roundNumber` column from customer and letter tables
- combine round info with status display
- keep action buttons tidy in the actions column
- prevent letter buttons from wrapping vertically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f290cc84832eb4815779c1ebde9d