### PR TITLE
Improve DataGrid wrapping for long rows

### DIFF
--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -320,7 +320,18 @@ export default function Customers() {
             onProcessRowUpdateError={(err) => setSnackbar(err.message)}
             experimentalFeatures={{ newEditingApi: true }}
             slots={{ toolbar: GridToolbar }}
-            sx={{ '& .MuiDataGrid-cell': { whiteSpace: 'normal', lineHeight: 1.4 } }}
+            autoHeight
+            getRowHeight={() => 'auto'}
+            sx={{
+              '& .MuiDataGrid-cell': {
+                whiteSpace: 'normal',
+                lineHeight: 1.4,
+              },
+              '& .MuiDataGrid-row': {
+                maxHeight: 'none !important',
+                alignItems: 'start',
+              },
+            }}
           />
         </div>
       </Paper>

--- a/credit-dashboard/src/pages/SendLetters.js
+++ b/credit-dashboard/src/pages/SendLetters.js
@@ -108,7 +108,18 @@ export default function SendLetters() {
               columns={columns}
               pageSize={5}
               rowsPerPageOptions={[5]}
-              sx={{ '& .MuiDataGrid-cell': { whiteSpace: 'normal', lineHeight: 1.4 } }}
+              autoHeight
+              getRowHeight={() => 'auto'}
+              sx={{
+                '& .MuiDataGrid-cell': {
+                  whiteSpace: 'normal',
+                  lineHeight: 1.4,
+                },
+                '& .MuiDataGrid-row': {
+                  maxHeight: 'none !important',
+                  alignItems: 'start',
+                },
+              }}
             />
           </div>
         {rows.length === 0 && <p>No letters ready to send.</p>}


### PR DESCRIPTION
## Summary
- allow Send Letters rows to grow naturally
- make Customers table support variable row heights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877f988c3a4832e991c198db821d811