### PR TITLE
Add clientInfo to bot payload

### DIFF
--- a/backend/routes/bot.js
+++ b/backend/routes/bot.js
@@ -42,6 +42,12 @@ const updateStatus = async (req, res) => {
         email: customer.email,
         address: customer.address,
         instructions: { strategy: 'aggressive' },
+        clientInfo: {
+          name: customer.customerName,
+          address: customer.address,
+          phone: customer.phone,
+          email: customer.email,
+        },
       };
 
       customer.botStatus = 'processing';

--- a/backend/server.js
+++ b/backend/server.js
@@ -116,6 +116,12 @@ cron.schedule('*/5 * * * *', async () => {
       address: customer.address,
       instructions: { strategy: 'aggressive' },
       mode: DEFAULT_MODE,
+      clientInfo: {
+        name: customer.customerName,
+        address: customer.address,
+        phone: customer.phone,
+        email: customer.email,
+      },
     };
 
     try {


### PR DESCRIPTION
## Summary
- add `clientInfo` object when sending data to bot
- include same structure in cron payload

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878040f8934832eb990837c800024fc