### PR TITLE
Implement basic JWT auth for dashboard

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,19 @@
+const jwt = require('jsonwebtoken');
+
+const SECRET = process.env.JWT_SECRET || 'supersecret';
+
+module.exports = function (req, res, next) {
+  const authHeader = req.headers.authorization || '';
+  if (!authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "mongodb": "^6.17.0",
     "mongoose": "^8.16.2",
     "multer": "^2.0.1",
-    "node-cron": "^3.0.3"
+    "node-cron": "^3.0.3",
+    "jsonwebtoken": "^9.0.2"
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const router = express.Router();
+
+const USERNAME = process.env.ADMIN_USER || 'admin';
+const PASSWORD = process.env.ADMIN_PASS || 'password123';
+const SECRET = process.env.JWT_SECRET || 'supersecret';
+
+router.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  if (username === USERNAME && password === PASSWORD) {
+    const token = jwt.sign({ username }, SECRET, { expiresIn: '1h' });
+    res.json({ token });
+  } else {
+    res.status(401).json({ error: 'Invalid credentials' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,8 @@ const dotenv = require('dotenv');
 const cron = require('node-cron');
 const axios = require('axios');
 const Customer = require('./models/Customer');
+const authRoutes = require('./routes/auth');
+const authMiddleware = require('./middleware/auth');
 
 dotenv.config();
 
@@ -45,9 +47,10 @@ const customersRoutes = require('./routes/customers');
 const uploadRoutes = require('./routes/upload');
 const botRoutes = require('./routes/bot');
 
-app.use('/api/customers', customersRoutes);
-app.use('/api/clients', customersRoutes); // alias for convenience
-app.use('/api/upload', uploadRoutes);
+app.use('/api', authRoutes);
+app.use('/api/customers', authMiddleware, customersRoutes);
+app.use('/api/clients', authMiddleware, customersRoutes); // alias for convenience
+app.use('/api/upload', authMiddleware, uploadRoutes);
 app.use('/api/bot', botRoutes);
 
 // simple health endpoint

--- a/credit-dashboard/src/App.js
+++ b/credit-dashboard/src/App.js
@@ -6,20 +6,41 @@ import Dashboard from './pages/Dashboard';
 import CustomerDetails from './pages/CustomerDetails';
 import Settings from './pages/Settings';
 import Layout from './Layout';
+import Login from './pages/Login';
+import AuthProvider from './AuthContext';
+import RequireAuth from './RequireAuth';
+
+function PrivateRoutes() {
+  return (
+    <Layout>
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/customers" element={<Customers />} />
+        <Route path="/customers/:id" element={<CustomerDetails />} />
+        <Route path="/work-today" element={<WorkToday />} />
+        <Route path="/send-letters" element={<SendLetters />} />
+        <Route path="/settings" element={<Settings />} />
+      </Routes>
+    </Layout>
+  );
+}
 
 function App() {
   return (
     <Router>
-      <Layout>
+      <AuthProvider>
         <Routes>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/customers" element={<Customers />} />
-          <Route path="/customers/:id" element={<CustomerDetails />} />
-          <Route path="/work-today" element={<WorkToday />} />
-          <Route path="/send-letters" element={<SendLetters />} />
-          <Route path="/settings" element={<Settings />} />
+          <Route path="/login" element={<Login />} />
+          <Route
+            path="/*"
+            element={
+              <RequireAuth>
+                <PrivateRoutes />
+              </RequireAuth>
+            }
+          />
         </Routes>
-      </Layout>
+      </AuthProvider>
     </Router>
   );
 }

--- a/credit-dashboard/src/AuthContext.js
+++ b/credit-dashboard/src/AuthContext.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const AuthContext = React.createContext({ token: null, login: async () => false });
+
+export default function AuthProvider({ children }) {
+  const [token, setToken] = React.useState(() => localStorage.getItem('token'));
+
+  const login = async (username, password) => {
+    try {
+      const res = await fetch('http://localhost:5000/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) return false;
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      setToken(data.token);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const value = React.useMemo(() => ({ token, login }), [token]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export { AuthContext };

--- a/credit-dashboard/src/RequireAuth.js
+++ b/credit-dashboard/src/RequireAuth.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { AuthContext } from './AuthContext';
+
+export default function RequireAuth({ children }) {
+  const { token } = React.useContext(AuthContext);
+  if (!token) return <Navigate to="/login" replace />;
+  return children;
+}

--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 import AddCustomerDialog from '../components/AddCustomerDialog';
 import ConfirmDialog from '../components/ConfirmDialog';
 import { AppModeContext } from '../ModeContext';
+import { AuthContext } from '../AuthContext';
 
 const formColumns = [
   { field: 'customerName', headerName: 'Customer Name', width: 150, editable: true },
@@ -54,12 +55,14 @@ export default function Customers() {
   const fileInputRef = React.useRef();
 
   const { mode } = React.useContext(AppModeContext);
+  const { token } = React.useContext(AuthContext);
 
   const BACKEND_URL = "http://localhost:5000";
   const API_URL = `${BACKEND_URL}/api/customers`;
+  const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
 
   React.useEffect(() => {
-    fetch(API_URL)
+    fetch(API_URL, { headers: authHeaders })
       .then(res => res.json())
       .then(data => {
         const mapped = data.map((c) => ({
@@ -85,7 +88,7 @@ export default function Customers() {
     if (payload.startDate) payload.startDate = new Date(payload.startDate);
     fetch(`${API_URL}/${newRow.id}`, {
       method: "PUT",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders },
       body: JSON.stringify(payload),
     })
       .then(res => res.json())
@@ -101,7 +104,7 @@ export default function Customers() {
     if (payload.startDate) payload.startDate = new Date(payload.startDate);
     fetch(API_URL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders },
       body: JSON.stringify(payload),
     })
       .then(res => res.json())
@@ -129,6 +132,7 @@ export default function Customers() {
     formData.append('file', file);
     fetch(`${BACKEND_URL}/api/upload/${uploadId}`, {
       method: 'POST',
+      headers: authHeaders,
       body: formData,
     })
       .then((res) => res.json())
@@ -153,7 +157,7 @@ export default function Customers() {
 
   const confirmDeleteCustomer = () => {
     if (!deleteId) return;
-    fetch(`${API_URL}/${deleteId}`, { method: "DELETE" })
+    fetch(`${API_URL}/${deleteId}`, { method: "DELETE", headers: authHeaders })
       .then(res => res.json())
       .then(() => {
         setRows((prev) => prev.filter((row) => row.id !== deleteId));
@@ -163,7 +167,7 @@ export default function Customers() {
   };
 
   const handleDeleteReport = (id) => {
-    fetch(`${BACKEND_URL}/api/upload/${id}`, { method: 'DELETE' })
+    fetch(`${BACKEND_URL}/api/upload/${id}`, { method: 'DELETE', headers: authHeaders })
       .then((res) => res.json())
       .then(() => {
         setRows((prev) =>
@@ -182,6 +186,7 @@ export default function Customers() {
       headers: {
         'Content-Type': 'application/json',
         'X-App-Mode': mode === 'real' ? 'Real' : 'Testing',
+        ...authHeaders,
       },
       body: JSON.stringify({ status: 'In Progress', mode }),
     })

--- a/credit-dashboard/src/pages/Login.js
+++ b/credit-dashboard/src/pages/Login.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { TextField, Button, Stack, Typography } from '@mui/material';
+import { AuthContext } from '../AuthContext';
+
+export default function Login() {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [error, setError] = React.useState('');
+  const { login } = React.useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const ok = await login(username, password);
+    if (ok) {
+      navigate('/');
+    } else {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack spacing={2} sx={{ width: 300, mx: 'auto', mt: 10 }}>
+        <Typography variant="h5">Login</Typography>
+        <TextField
+          label="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <TextField
+          label="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && (
+          <Typography color="error" variant="body2">
+            {error}
+          </Typography>
+        )}
+        <Button type="submit" variant="contained">
+          Login
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/credit-dashboard/src/pages/SendLetters.js
+++ b/credit-dashboard/src/pages/SendLetters.js
@@ -4,6 +4,7 @@ import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import { AuthContext } from '../AuthContext';
 
 const BACKEND_URL = 'http://localhost:5000';
 const API_URL = `${BACKEND_URL}/api/customers/letters-ready`;
@@ -71,11 +72,13 @@ const columns = [
 
 export default function SendLetters() {
   const [rows, setRows] = React.useState([]);
+  const { token } = React.useContext(AuthContext);
+  const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
 
   const markCompleted = (id) => {
     fetch(`${BACKEND_URL}/api/customers/${id}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders },
       body: JSON.stringify({ status: 'Completed' }),
     })
       .then((res) => res.json())
@@ -86,7 +89,7 @@ export default function SendLetters() {
   };
 
   React.useEffect(() => {
-    fetch(API_URL)
+    fetch(API_URL, { headers: authHeaders })
       .then((res) => res.json())
       .then((data) => {
         const mapped = data.map((c) => ({

--- a/credit-dashboard/src/pages/WorkToday.js
+++ b/credit-dashboard/src/pages/WorkToday.js
@@ -3,6 +3,7 @@ import { DataGrid } from '@mui/x-data-grid';
 import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Chip from '@mui/material/Chip';
+import { AuthContext } from '../AuthContext';
 
 
 
@@ -50,10 +51,12 @@ const columns = [
 export default function WorkToday() {
   const [rows, setRows] = React.useState([]);
   const API_URL = 'http://localhost:5000/api/customers/today';
+  const { token } = React.useContext(AuthContext);
+  const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
 
   React.useEffect(() => {
     const fetchData = () => {
-      fetch(API_URL)
+      fetch(API_URL, { headers: authHeaders })
         .then(res => res.json())
         .then(data => {
           const mapped = data.map((c) => ({


### PR DESCRIPTION
## Summary
- create login API route returning JWT
- protect customer/upload endpoints with JWT middleware
- add React auth context and login page
- require auth for dashboard routes and pass token on fetches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782b752a80832e8d5fabcdd2deed82