### PR TITLE
Fix token-dependent fetches in dashboard

### DIFF
--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -62,7 +62,8 @@ export default function Customers() {
   const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
 
   React.useEffect(() => {
-    fetch(API_URL, { headers: authHeaders })
+    if (!token) return;
+    fetch(API_URL, { headers: { Authorization: `Bearer ${token}` } })
       .then(res => res.json())
       .then(data => {
         const mapped = data.map((c) => ({
@@ -73,7 +74,7 @@ export default function Customers() {
         setRows(mapped);
       })
       .catch(err => console.error(err));
-  }, []);
+  }, [token]);
 
   const requiredFields = ['customerName', 'phone', 'email', 'address', 'startDate'];
 

--- a/credit-dashboard/src/pages/SendLetters.js
+++ b/credit-dashboard/src/pages/SendLetters.js
@@ -89,7 +89,8 @@ export default function SendLetters() {
   };
 
   React.useEffect(() => {
-    fetch(API_URL, { headers: authHeaders })
+    if (!token) return;
+    fetch(API_URL, { headers: { Authorization: `Bearer ${token}` } })
       .then((res) => res.json())
       .then((data) => {
         const mapped = data.map((c) => ({
@@ -100,7 +101,7 @@ export default function SendLetters() {
         setRows(mapped);
       })
       .catch((err) => console.error(err));
-  }, []);
+  }, [token]);
 
   return (
     <Container sx={{ mt: 4 }}>

--- a/credit-dashboard/src/pages/WorkToday.js
+++ b/credit-dashboard/src/pages/WorkToday.js
@@ -56,8 +56,9 @@ export default function WorkToday() {
   const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
 
   React.useEffect(() => {
+    if (!token) return;
     const fetchData = () => {
-      fetch(API_URL, { headers: authHeaders })
+      fetch(API_URL, { headers: { Authorization: `Bearer ${token}` } })
         .then(res => res.json())
         .then(data => {
           const mapped = data.map((c) => ({
@@ -73,7 +74,7 @@ export default function WorkToday() {
     fetchData();
     const interval = setInterval(fetchData, 30000);
     return () => clearInterval(interval);
-  }, []);
+  }, [token]);
 
   return (
     <Container sx={{ mt: 4 }}>


### PR DESCRIPTION
## Summary
- ensure token is present before requesting customer data
- update SendLetters and WorkToday pages to wait for token

## Testing
- `OPENAI_API_KEY=dummy pytest -q`
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68793616ccd0832eabd4d68262099cfb