### PR TITLE
Add customer refresh feature

### DIFF
--- a/credit-dashboard/src/App.js
+++ b/credit-dashboard/src/App.js
@@ -9,6 +9,7 @@ import Layout from './Layout';
 import Login from './pages/Login';
 import AuthProvider from './AuthContext';
 import RequireAuth from './RequireAuth';
+import CustomersProvider from './CustomersContext';
 
 function PrivateRoutes() {
   return (
@@ -35,7 +36,9 @@ function App() {
             path="/*"
             element={
               <RequireAuth>
-                <PrivateRoutes />
+                <CustomersProvider>
+                  <PrivateRoutes />
+                </CustomersProvider>
               </RequireAuth>
             }
           />

--- a/credit-dashboard/src/CustomersContext.js
+++ b/credit-dashboard/src/CustomersContext.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { AuthContext } from './AuthContext';
+
+const CustomersContext = React.createContext({
+  customers: [],
+  setCustomers: () => {},
+  refreshCustomers: () => {},
+});
+
+export default function CustomersProvider({ children }) {
+  const { token } = React.useContext(AuthContext);
+  const [customers, setCustomers] = React.useState([]);
+
+  const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || '';
+  const API_URL = `${BACKEND_URL}/api/customers`;
+
+  const refreshCustomers = React.useCallback(async () => {
+    if (!token) return;
+    try {
+      const res = await fetch(API_URL, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      const mapped = data.map((c) => ({
+        ...c,
+        id: c.id || c._id,
+        startDate: c.startDate ? c.startDate.slice(0, 10) : '',
+      }));
+      setCustomers(mapped);
+    } catch (err) {
+      console.error(err);
+    }
+  }, [token]);
+
+  React.useEffect(() => {
+    if (token) {
+      refreshCustomers();
+    }
+  }, [token, refreshCustomers]);
+
+  const value = React.useMemo(
+    () => ({ customers, setCustomers, refreshCustomers }),
+    [customers, refreshCustomers]
+  );
+
+  return (
+    <CustomersContext.Provider value={value}>
+      {children}
+    </CustomersContext.Provider>
+  );
+}
+
+export { CustomersContext };

--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -10,6 +10,7 @@ import AddCustomerDialog from '../components/AddCustomerDialog';
 import ConfirmDialog from '../components/ConfirmDialog';
 import { AppModeContext } from '../ModeContext';
 import { AuthContext } from '../AuthContext';
+import { CustomersContext } from '../CustomersContext';
 
 const formColumns = [
   { field: 'customerName', headerName: 'Customer Name', width: 150, editable: true },
@@ -46,7 +47,7 @@ const formColumns = [
 ];
 
 export default function Customers() {
-  const [rows, setRows] = React.useState([]);
+  const { customers: rows, setCustomers: setRows, refreshCustomers } = React.useContext(CustomersContext);
   const [open, setOpen] = React.useState(false);
   const [newCustomer, setNewCustomer] = React.useState({ status: 'New', roundNumber: 1 });
   const [snackbar, setSnackbar] = React.useState('');
@@ -62,19 +63,10 @@ export default function Customers() {
   const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
 
   React.useEffect(() => {
-    if (!token) return;
-    fetch(API_URL, { headers: { Authorization: `Bearer ${token}` } })
-      .then(res => res.json())
-      .then(data => {
-        const mapped = data.map((c) => ({
-          ...c,
-          id: c.id || c._id,
-          startDate: c.startDate ? c.startDate.slice(0, 10) : ''
-        }));
-        setRows(mapped);
-      })
-      .catch(err => console.error(err));
-  }, [token]);
+    if (token) {
+      refreshCustomers();
+    }
+  }, [token, refreshCustomers]);
 
   const requiredFields = ['customerName', 'phone', 'email', 'address', 'startDate'];
 

--- a/credit-dashboard/src/pages/Settings.js
+++ b/credit-dashboard/src/pages/Settings.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Typography, Button, Stack, Chip } from '@mui/material';
 import { AppModeContext } from '../ModeContext';
+import { CustomersContext } from '../CustomersContext';
 
 export default function Settings() {
   const { mode, setMode } = React.useContext(AppModeContext);
+  const { refreshCustomers } = React.useContext(CustomersContext);
 
   return (
     <Stack spacing={3}>
@@ -28,6 +30,11 @@ export default function Settings() {
           onClick={() => setMode('real')}
         >
           Real Mode
+        </Button>
+      </Stack>
+      <Stack direction="row">
+        <Button variant="outlined" onClick={refreshCustomers}>
+          Refresh Customers
         </Button>
       </Stack>
     </Stack>


### PR DESCRIPTION
## Summary
- implement `CustomersContext` for shared customer state
- auto-refresh when token is ready in `Customers` page
- add manual **Refresh Customers** button on Settings page
- wrap private routes with `CustomersProvider`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793bfad5fc832ea1a357996292c914