### PR TITLE
docs: list admin vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ AWS_REGION=us-east-1
 AWS_S3_BUCKET=your-bucket-name
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret
+JWT_SECRET=your-jwt-secret
+ADMIN_USER=admin
+ADMIN_PASS=change-me
 
 # Bot service
 BACKEND_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ values for your setup.
 - `BOT_START_URL` — endpoint to start or ping the bot service
 - `APP_MODE` — "real" or "testing" to control how the bot generates letters
 - `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` — storage credentials
+- `JWT_SECRET` — secret key for signing JSON Web Tokens
+- `ADMIN_USER` — default admin username
+- `ADMIN_PASS` — default admin password
 
 ### Bot
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,3 +7,6 @@ AWS_REGION=us-east-1
 AWS_S3_BUCKET=your-bucket-name
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret
+JWT_SECRET=your-jwt-secret
+ADMIN_USER=admin
+ADMIN_PASS=change-me


### PR DESCRIPTION
## Summary
- add JWT_SECRET, ADMIN_USER, ADMIN_PASS to backend variable list in README
- include placeholder values for these variables in `.env.example` and `backend/.env.example`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68794c8438cc832e89dc5616ed911a10