### PR TITLE
Handle expired JWT tokens

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -14,6 +14,11 @@ module.exports = function (req, res, next) {
     req.user = decoded;
     next();
   } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      console.error('JWT verification error:', err);
+      return res.status(401).json({ error: 'Token expired' });
+    }
+    console.error('JWT verification error:', err);
     return res.status(401).json({ error: 'Invalid token' });
   }
 };


### PR DESCRIPTION
## Summary
- add TokenExpiredError check in `backend/middleware/auth.js`
- log JWT verification errors for debugging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794c84c430832e8163b3e05b6b35df