### PR TITLE
Improve auth handling

### DIFF
--- a/credit-dashboard/src/AuthContext.js
+++ b/credit-dashboard/src/AuthContext.js
@@ -1,11 +1,28 @@
 import React from 'react';
 
-const AuthContext = React.createContext({ token: null, login: async () => false });
+const AuthContext = React.createContext({
+  token: null,
+  login: async () => false,
+  logout: () => {},
+});
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || '';
 
+function decodeJwt(t) {
+  try {
+    return JSON.parse(atob(t.split('.')[1]));
+  } catch {
+    return null;
+  }
+}
+
 export default function AuthProvider({ children }) {
   const [token, setToken] = React.useState(() => localStorage.getItem('token'));
+
+  const logout = React.useCallback(() => {
+    localStorage.removeItem('token');
+    setToken(null);
+  }, []);
 
   const login = async (username, password) => {
     try {
@@ -24,7 +41,20 @@ export default function AuthProvider({ children }) {
     }
   };
 
-  const value = React.useMemo(() => ({ token, login }), [token]);
+  React.useEffect(() => {
+    if (!token) return;
+    const payload = decodeJwt(token);
+    if (!payload?.exp) return;
+    const expiresIn = payload.exp * 1000 - Date.now();
+    if (expiresIn <= 0) {
+      logout();
+      return;
+    }
+    const id = setTimeout(logout, expiresIn);
+    return () => clearTimeout(id);
+  }, [token, logout]);
+
+  const value = React.useMemo(() => ({ token, login, logout }), [token, login, logout]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/credit-dashboard/src/CustomersContext.js
+++ b/credit-dashboard/src/CustomersContext.js
@@ -8,7 +8,7 @@ const CustomersContext = React.createContext({
 });
 
 export default function CustomersProvider({ children }) {
-  const { token } = React.useContext(AuthContext);
+  const { token, logout } = React.useContext(AuthContext);
   const [customers, setCustomers] = React.useState([]);
 
   const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || '';
@@ -22,7 +22,8 @@ export default function CustomersProvider({ children }) {
         headers: { Authorization: `Bearer ${authToken}` },
       });
       if (res.status === 401) {
-        console.error('Unauthorized when fetching customers');
+        logout();
+        window.location.assign('/login');
         return;
       }
       const data = await res.json();
@@ -39,7 +40,7 @@ export default function CustomersProvider({ children }) {
     } catch (err) {
       console.error(err);
     }
-  }, [token]);
+  }, [token, logout]);
 
   React.useEffect(() => {
     if (token) {

--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -56,7 +56,16 @@ export default function Customers() {
   const fileInputRef = React.useRef();
 
   const { mode } = React.useContext(AppModeContext);
-  const { token } = React.useContext(AuthContext);
+  const { token, logout } = React.useContext(AuthContext);
+
+  const checkAuth = (res) => {
+    if (res.status === 401) {
+      logout();
+      window.location.assign('/login');
+      return true;
+    }
+    return false;
+  };
 
   const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || '';
   const API_URL = `${BACKEND_URL}/api/customers`;
@@ -84,7 +93,10 @@ export default function Customers() {
       headers: { "Content-Type": "application/json", ...authHeaders },
       body: JSON.stringify(payload),
     })
-      .then(res => res.json())
+      .then(res => {
+        if (checkAuth(res)) return Promise.reject('unauthorized');
+        return res.json();
+      })
       .then(data => {
         const updated = { ...data, id: data.id || data._id };
         setRows((prev) => prev.map((row) => (row.id === updated.id ? updated : row)));
@@ -100,7 +112,10 @@ export default function Customers() {
       headers: { "Content-Type": "application/json", ...authHeaders },
       body: JSON.stringify(payload),
     })
-      .then(res => res.json())
+      .then(res => {
+        if (checkAuth(res)) return Promise.reject('unauthorized');
+        return res.json();
+      })
       .then(data => {
         const mapped = { ...data, id: data.id || data._id };
         setRows((prev) => [...prev, mapped]);
@@ -128,7 +143,10 @@ export default function Customers() {
       headers: authHeaders,
       body: formData,
     })
-      .then((res) => res.json())
+      .then((res) => {
+        if (checkAuth(res)) return Promise.reject('unauthorized');
+        return res.json();
+      })
       .then((data) => {
         setRows((prev) =>
           prev.map((row) =>
@@ -151,7 +169,10 @@ export default function Customers() {
   const confirmDeleteCustomer = () => {
     if (!deleteId) return;
     fetch(`${API_URL}/${deleteId}`, { method: "DELETE", headers: authHeaders })
-      .then(res => res.json())
+      .then(res => {
+        if (checkAuth(res)) return Promise.reject('unauthorized');
+        return res.json();
+      })
       .then(() => {
         setRows((prev) => prev.filter((row) => row.id !== deleteId));
         setSnackbar('Customer deleted');
@@ -161,7 +182,10 @@ export default function Customers() {
 
   const handleDeleteReport = (id) => {
     fetch(`${BACKEND_URL}/api/upload/${id}`, { method: 'DELETE', headers: authHeaders })
-      .then((res) => res.json())
+      .then((res) => {
+        if (checkAuth(res)) return Promise.reject('unauthorized');
+        return res.json();
+      })
       .then(() => {
         setRows((prev) =>
           prev.map((row) =>
@@ -183,7 +207,10 @@ export default function Customers() {
       },
       body: JSON.stringify({ status: 'In Progress', mode }),
     })
-      .then((res) => res.json())
+      .then((res) => {
+        if (checkAuth(res)) return Promise.reject('unauthorized');
+        return res.json();
+      })
       .then((data) => {
         const updated = { ...data.customer, id: data.customer._id };
         setRows((prev) => prev.map((row) => (row.id === id ? updated : row)));

--- a/credit-dashboard/src/pages/WorkToday.js
+++ b/credit-dashboard/src/pages/WorkToday.js
@@ -52,14 +52,26 @@ export default function WorkToday() {
   const [rows, setRows] = React.useState([]);
   const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || '';
   const API_URL = `${BACKEND_URL}/api/customers/today`;
-  const { token } = React.useContext(AuthContext);
+  const { token, logout } = React.useContext(AuthContext);
   const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
+
+  const checkAuth = (res) => {
+    if (res.status === 401) {
+      logout();
+      window.location.assign('/login');
+      return true;
+    }
+    return false;
+  };
 
   React.useEffect(() => {
     if (!token) return;
     const fetchData = () => {
       fetch(API_URL, { headers: { Authorization: `Bearer ${token}` } })
-        .then(res => res.json())
+        .then(res => {
+          if (checkAuth(res)) return Promise.reject('unauthorized');
+          return res.json();
+        })
         .then(data => {
           const mapped = data.map((c) => ({
             ...c,


### PR DESCRIPTION
## Summary
- enforce automatic logout when token expires in AuthProvider
- handle 401 errors across data fetchers and redirect to login

## Testing
- `pytest -q`
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68794c8561d8832eaf8d7f45c06dea29