### PR TITLE
Use env vars for admin login and JWT secret

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,6 +1,6 @@
 const jwt = require('jsonwebtoken');
 
-const SECRET = process.env.JWT_SECRET || 'supersecret';
+const SECRET = process.env.JWT_SECRET;
 
 module.exports = function (req, res, next) {
   const authHeader = req.headers.authorization || '';

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -2,9 +2,9 @@ const express = require('express');
 const jwt = require('jsonwebtoken');
 const router = express.Router();
 
-const USERNAME = process.env.ADMIN_USER || 'admin';
-const PASSWORD = process.env.ADMIN_PASS || 'password123';
-const SECRET = process.env.JWT_SECRET || 'supersecret';
+const USERNAME = process.env.ADMIN_USER;
+const PASSWORD = process.env.ADMIN_PASS;
+const SECRET = process.env.JWT_SECRET;
 
 router.post('/login', (req, res) => {
   const { username, password } = req.body;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,14 +1,12 @@
+require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const mongoose = require('mongoose');
-const dotenv = require('dotenv');
 const cron = require('node-cron');
 const axios = require('axios');
 const Customer = require('./models/Customer');
 const authRoutes = require('./routes/auth');
 const authMiddleware = require('./middleware/auth');
-
-dotenv.config();
 
 function resolveMode(value) {
   return String(value || '').toLowerCase().startsWith('test') ? 'testing' : 'real';


### PR DESCRIPTION
## Summary
- load dotenv at the top of the backend server
- reference admin user, admin password and JWT secret from environment variables only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879555651d8832eb34d42271dc8e217