### PR TITLE
Protect bot routes with auth middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,4 @@ ADMIN_PASS=change-me
 
 # Bot service
 BACKEND_URL=http://localhost:5000
+BOT_TOKEN=

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ values for your setup.
 ### Bot
 
 - `BACKEND_URL` — URL to the backend callback endpoint
+ - `BOT_TOKEN` — JWT token used when the bot service calls `/api/bot/*`
 - The same AWS variables as above if uploading to the same bucket
 - Any additional API keys (e.g., OpenAI) placed in `.env`
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -49,7 +49,7 @@ app.use('/api', authRoutes);
 app.use('/api/customers', authMiddleware, customersRoutes);
 app.use('/api/clients', authMiddleware, customersRoutes); // alias for convenience
 app.use('/api/upload', authMiddleware, uploadRoutes);
-app.use('/api/bot', botRoutes);
+app.use('/api/bot', authMiddleware, botRoutes);
 
 // simple health endpoint
 app.get('/api/status', (req, res) => {

--- a/bot_service/.env.example
+++ b/bot_service/.env.example
@@ -1,5 +1,6 @@
 PORT=6000
 BACKEND_URL=http://localhost:5000
+BOT_TOKEN=
 AWS_REGION=us-east-1
 AWS_S3_BUCKET=your-bucket-name
 AWS_ACCESS_KEY_ID=your-access-key

--- a/bot_service/README.md
+++ b/bot_service/README.md
@@ -18,6 +18,7 @@ Environment variables are read from a `.env` file or the environment:
 - `AWS_S3_BUCKET`
 - `AWS_REGION`
 - `BACKEND_URL` (e.g. `http://localhost:5000`)
+ - `BOT_TOKEN` — JWT token used to call the backend `/api/bot/*` endpoints
 - `PORT` (default 6000)
 - `APP_MODE` (optional) — default mode when no header/body value is provided
 

--- a/bot_service/services/backend_comm.py
+++ b/bot_service/services/backend_comm.py
@@ -2,6 +2,7 @@ import os
 import requests
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:5000")
+BOT_TOKEN = os.getenv("BOT_TOKEN")
 
 
 def send_results(client_id: str, letters: list[dict], error: str | None = None):
@@ -10,8 +11,11 @@ def send_results(client_id: str, letters: list[dict], error: str | None = None):
     if error:
         payload["error"] = error
     url = f"{BACKEND_URL}/api/bot/result"
+    headers = {}
+    if BOT_TOKEN:
+        headers["Authorization"] = f"Bearer {BOT_TOKEN}"
     try:
-        resp = requests.post(url, json=payload, timeout=10)
+        resp = requests.post(url, json=payload, headers=headers, timeout=10)
         resp.raise_for_status()
         return resp.json()
     except requests.RequestException as e:


### PR DESCRIPTION
## Summary
- protect bot routes using the auth middleware
- allow the bot service to send its JWT token when calling the backend
- document the new `BOT_TOKEN` variable

## Testing
- `pip install -r bot_service/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68798a048264832eb6da693733a05a40