### PR TITLE
Add configurable CORS origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Backend configuration
 MONGO_URI=mongodb://localhost:27017/creditdb
 PORT=5000
+ALLOWED_ORIGIN=http://localhost:3000
 BOT_PROCESS_URL=http://localhost:6000/api/bot/process
 BOT_START_URL=http://localhost:6000/start
 APP_MODE=testing

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ values for your setup.
 
 - `MONGO_URI` — MongoDB connection string
 - `PORT` — port for the Node server (default 5000)
+- `ALLOWED_ORIGIN` — origin allowed for CORS requests
 - `BOT_PROCESS_URL` — bot endpoint for processing requests
 - `BOT_START_URL` — endpoint to start or ping the bot service
 - `APP_MODE` — "real" or "testing" to control how the bot generates letters

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,12 +13,13 @@ function resolveMode(value) {
 }
 
 const DEFAULT_MODE = resolveMode(process.env.APP_MODE || 'real');
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || '*';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
 
 // Middleware
-app.use(cors());
+app.use(cors({ origin: ALLOWED_ORIGIN }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION
## Summary
- make backend CORS origin configurable
- document `ALLOWED_ORIGIN` env variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a746e9c64832eb1b653ad41abe334