### PR TITLE
Enforce file upload limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ locally so that both services reference the same directory.
 
 Folders are created automatically if they do not exist.
 
+Uploads are limited to **10MB** and must be PDF files. Any other type or larger
+file will be rejected with a `400` error.
+
 ## 📄 Recommended start order
 
 1️⃣ Start the **bot service** (Python) first — so the backend can communicate with it.  


### PR DESCRIPTION
## Summary
- allow only PDF uploads up to 10MB in upload route
- return 400 errors for disallowed types and oversized files
- note upload limits in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a746e58d0832eb666db80fee5f749