### PR TITLE
Add ID validation middleware and tests

### DIFF
--- a/backend/routes/customers.js
+++ b/backend/routes/customers.js
@@ -5,6 +5,15 @@ const path = require('path');
 const AWS = require('aws-sdk');
 const Customer = require('../models/Customer');
 
+const objectIdPattern = /^[a-f0-9]{24}$/i;
+
+router.param('id', (req, res, next, id) => {
+  if (!objectIdPattern.test(id)) {
+    return res.status(400).json({ error: 'Invalid ID' });
+  }
+  next();
+});
+
 // Create new customer
 router.post('/', async (req, res) => {
   try {

--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -6,6 +6,15 @@ const path = require('path');
 const AWS = require('aws-sdk');
 const Customer = require('../models/Customer');
 
+const objectIdPattern = /^[a-f0-9]{24}$/i;
+
+router.param('id', (req, res, next, id) => {
+  if (!objectIdPattern.test(id)) {
+    return res.status(400).json({ error: 'Invalid ID' });
+  }
+  next();
+});
+
 // הגדרה של אחסון מקומי
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {

--- a/tests/test_id_validation.js
+++ b/tests/test_id_validation.js
@@ -1,0 +1,73 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const express = require('../backend/node_modules/express');
+
+const VALID_ID = '0123456789abcdef01234567';
+const INVALID_ID = '12345';
+
+const customerModelPath = require('path').resolve(__dirname, '../backend/models/Customer.js');
+
+function withRouter(routerPath, handler) {
+  const customerStub = {
+    findById: async () => null,
+    findByIdAndDelete: async () => null,
+    save: async () => null
+  };
+  const cached = require.cache[customerModelPath];
+  require.cache[customerModelPath] = { exports: customerStub };
+  const router = require(routerPath);
+
+  const app = express();
+  app.use(express.json());
+  app.use('/', router);
+
+  return handler(app).finally(() => {
+    if (cached) {
+      require.cache[customerModelPath] = cached;
+    } else {
+      delete require.cache[customerModelPath];
+    }
+  });
+}
+
+function request(app, method, path) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address();
+      fetch(`http://localhost:${port}${path}`, { method })
+        .then(async (res) => {
+          server.close();
+          resolve({ status: res.status });
+        })
+        .catch((err) => { server.close(); reject(err); });
+    });
+  });
+}
+
+test('customers route rejects invalid id', async () => {
+  await withRouter('../backend/routes/customers', async (app) => {
+    const res = await request(app, 'GET', `/${INVALID_ID}`);
+    assert.strictEqual(res.status, 400);
+  });
+});
+
+test('customers route allows valid id', async () => {
+  await withRouter('../backend/routes/customers', async (app) => {
+    const res = await request(app, 'GET', `/${VALID_ID}`);
+    assert.strictEqual(res.status, 404);
+  });
+});
+
+test('upload route rejects invalid id', async () => {
+  await withRouter('../backend/routes/upload', async (app) => {
+    const res = await request(app, 'DELETE', `/${INVALID_ID}`);
+    assert.strictEqual(res.status, 400);
+  });
+});
+
+test('upload route allows valid id', async () => {
+  await withRouter('../backend/routes/upload', async (app) => {
+    const res = await request(app, 'DELETE', `/${VALID_ID}`);
+    assert.strictEqual(res.status, 404);
+  });
+});


### PR DESCRIPTION
## Summary
- validate `:id` params in customers and upload routers
- test invalid and valid IDs with Node's test runner

## Testing
- `pytest -q`
- `node --test tests/test_id_validation.js`


------
https://chatgpt.com/codex/tasks/task_e_687a746e2b94832e82b252a105de9dd9