### PR TITLE
Use hashed password in backend auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret
 JWT_SECRET=your-jwt-secret
 ADMIN_USER=admin
-ADMIN_PASS=change-me
+# format: <salt>$<scrypt hash>
+ADMIN_PASS_HASH=somesalt$ca944dff8f94a0252619d883cc797b6312a207286cc3c452e520faed2afd12f9652a9f643f082812b5b6253c675796542eff78329bd7180207e024517ce4aa8f
 
 # Bot service
 BACKEND_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ values for your setup.
 - `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` — storage credentials
 - `JWT_SECRET` — secret key for signing JSON Web Tokens
 - `ADMIN_USER` — default admin username
-- `ADMIN_PASS` — default admin password
+- `ADMIN_PASS_HASH` — scrypt hash of the admin password in the form `salt$hash`
 
 ### Bot
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,4 +9,5 @@ AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret
 JWT_SECRET=your-jwt-secret
 ADMIN_USER=admin
-ADMIN_PASS=change-me
+# format: <salt>$<scrypt hash>
+ADMIN_PASS_HASH=somesalt$ca944dff8f94a0252619d883cc797b6312a207286cc3c452e520faed2afd12f9652a9f643f082812b5b6253c675796542eff78329bd7180207e024517ce4aa8f

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,14 +1,24 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
 const router = express.Router();
+const crypto = require('crypto');
 
 const USERNAME = process.env.ADMIN_USER;
-const PASSWORD = process.env.ADMIN_PASS;
+const PASS_DATA = process.env.ADMIN_PASS_HASH || '';
 const SECRET = process.env.JWT_SECRET;
+
+function verifyPassword(input) {
+  const [salt, stored] = PASS_DATA.split('$');
+  if (!salt || !stored) return false;
+  const hash = crypto.scryptSync(input, salt, 64);
+  const storedBuf = Buffer.from(stored, 'hex');
+  if (storedBuf.length !== hash.length) return false;
+  return crypto.timingSafeEqual(hash, storedBuf);
+}
 
 router.post('/login', (req, res) => {
   const { username, password } = req.body;
-  if (username === USERNAME && password === PASSWORD) {
+  if (username === USERNAME && verifyPassword(password)) {
     const token = jwt.sign({ username }, SECRET, { expiresIn: '1h' });
     res.json({ token });
   } else {


### PR DESCRIPTION
## Summary
- hash the admin password using `crypto.scryptSync`
- add verification helper in `auth.js`
- store the hashed password in `ADMIN_PASS_HASH` env variable
- document the hashed password format in the README and env examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a746f1020832eb15545a4614e0517