### PR TITLE
Add bot JWT auth for /api/bot/result

### DIFF
--- a/backend/middleware/authBot.js
+++ b/backend/middleware/authBot.js
@@ -1,0 +1,33 @@
+const jwt = require('jsonwebtoken');
+
+const SECRET = process.env.JWT_SECRET;
+const BOT_TOKEN = process.env.BOT_TOKEN;
+
+module.exports = function (req, res, next) {
+  const authHeader = req.headers.authorization || '';
+  if (!authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const token = authHeader.split(' ')[1];
+  if (!BOT_TOKEN) {
+    console.error('BOT_TOKEN not configured');
+    return res.status(500).json({ error: 'Server misconfigured' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, SECRET);
+    if (token !== BOT_TOKEN) {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+    req.bot = decoded;
+    next();
+  } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      console.error('Bot JWT verification error:', err);
+      return res.status(401).json({ error: 'Token expired' });
+    }
+    console.error('Bot JWT verification error:', err);
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+};

--- a/backend/routes/bot.js
+++ b/backend/routes/bot.js
@@ -2,6 +2,8 @@ const express = require('express');
 const router = express.Router();
 const axios = require('axios');
 const Customer = require('../models/Customer');
+const authMiddleware = require('../middleware/auth');
+const botAuth = require('../middleware/authBot');
 
 function getMode(req) {
   const value =
@@ -77,11 +79,11 @@ const updateStatus = async (req, res) => {
   }
 };
 
-router.put('/:id/status', updateStatus);
-router.patch('/:id/status', updateStatus);
+router.put('/:id/status', authMiddleware, updateStatus);
+router.patch('/:id/status', authMiddleware, updateStatus);
 
 // Endpoint for bot to send results
-router.post('/result', async (req, res) => {
+router.post('/result', botAuth, async (req, res) => {
   try {
     const { clientId, letters, error } = req.body;
     let update;

--- a/backend/server.js
+++ b/backend/server.js
@@ -50,7 +50,8 @@ app.use('/api', authRoutes);
 app.use('/api/customers', authMiddleware, customersRoutes);
 app.use('/api/clients', authMiddleware, customersRoutes); // alias for convenience
 app.use('/api/upload', authMiddleware, uploadRoutes);
-app.use('/api/bot', authMiddleware, botRoutes);
+// Bot routes handle their own authentication
+app.use('/api/bot', botRoutes);
 
 // simple health endpoint
 app.get('/api/status', (req, res) => {


### PR DESCRIPTION
## Summary
- implement JWT auth middleware for bot interactions
- secure /api/bot/result with the new middleware
- delegate authentication for other bot routes in router

## Testing
- `npm --prefix backend test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687abd193310832eb219092ed45cd51b