### PR TITLE
Switch bot authentication to shared secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ values for your setup.
 ### Bot
 
 - `BACKEND_URL` — URL to the backend callback endpoint
- - `BOT_TOKEN` — JWT token used when the bot service calls `/api/bot/*`
+ - `BOT_TOKEN` — shared secret used when the bot service calls `/api/bot/*`
 - The same AWS variables as above if uploading to the same bucket
 - Any additional API keys (e.g., OpenAI) placed in `.env`
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,7 @@ AWS_S3_BUCKET=your-bucket-name
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret
 JWT_SECRET=your-jwt-secret
+BOT_TOKEN=your_shared_secret_here
 ADMIN_USER=admin
 # format: <salt>$<scrypt hash>
 ADMIN_PASS_HASH=somesalt$ca944dff8f94a0252619d883cc797b6312a207286cc3c452e520faed2afd12f9652a9f643f082812b5b6253c675796542eff78329bd7180207e024517ce4aa8f

--- a/backend/middleware/authBot.js
+++ b/backend/middleware/authBot.js
@@ -1,6 +1,3 @@
-const jwt = require('jsonwebtoken');
-
-const SECRET = process.env.JWT_SECRET;
 const BOT_TOKEN = process.env.BOT_TOKEN;
 
 module.exports = function (req, res, next) {
@@ -15,19 +12,9 @@ module.exports = function (req, res, next) {
     return res.status(500).json({ error: 'Server misconfigured' });
   }
 
-  try {
-    const decoded = jwt.verify(token, SECRET);
-    if (token !== BOT_TOKEN) {
-      return res.status(401).json({ error: 'Invalid token' });
-    }
-    req.bot = decoded;
-    next();
-  } catch (err) {
-    if (err.name === 'TokenExpiredError') {
-      console.error('Bot JWT verification error:', err);
-      return res.status(401).json({ error: 'Token expired' });
-    }
-    console.error('Bot JWT verification error:', err);
+  if (token !== BOT_TOKEN) {
     return res.status(401).json({ error: 'Invalid token' });
   }
+
+  next();
 };

--- a/bot_service/README.md
+++ b/bot_service/README.md
@@ -18,7 +18,7 @@ Environment variables are read from a `.env` file or the environment:
 - `AWS_S3_BUCKET`
 - `AWS_REGION`
 - `BACKEND_URL` (e.g. `http://localhost:5000`)
- - `BOT_TOKEN` — JWT token used to call the backend `/api/bot/*` endpoints
+ - `BOT_TOKEN` — shared secret used to call the backend `/api/bot/*` endpoints
 - `PORT` (default 6000)
 - `APP_MODE` (optional) — default mode when no header/body value is provided
 


### PR DESCRIPTION
## Summary
- accept a shared secret BOT_TOKEN instead of verifying JWTs
- document new BOT_TOKEN usage in README files
- add BOT_TOKEN to backend `.env.example`

## Testing
- `node --test tests/test_id_validation.js`
- `pytest -q tests/test_main.py tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_687ac380d210832eae48a2287ceea3a7