### PR TITLE
Add debug log for bot auth token

### DIFF
--- a/backend/middleware/authBot.js
+++ b/backend/middleware/authBot.js
@@ -2,6 +2,7 @@ const BOT_TOKEN = process.env.BOT_TOKEN;
 
 module.exports = function (req, res, next) {
   const authHeader = req.headers.authorization || '';
+  console.log('[botAuth] header:', req.headers.authorization, 'expected:', BOT_TOKEN);
   if (!authHeader.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'Unauthorized' });
   }


### PR DESCRIPTION
## Summary
- add log of `authorization` header to `authBot` middleware

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac8604b08832e969cfaaadecdb4a3