### PR TITLE
Ensure BOT_TOKEN header is sent

### DIFF
--- a/bot_service/services/backend_comm.py
+++ b/bot_service/services/backend_comm.py
@@ -1,8 +1,8 @@
 import os
 import requests
+import logging
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:5000")
-BOT_TOKEN = os.getenv("BOT_TOKEN")
 
 
 def send_results(client_id: str, letters: list[dict], error: str | None = None):
@@ -12,8 +12,10 @@ def send_results(client_id: str, letters: list[dict], error: str | None = None):
         payload["error"] = error
     url = f"{BACKEND_URL}/api/bot/result"
     headers = {}
-    if BOT_TOKEN:
-        headers["Authorization"] = f"Bearer {BOT_TOKEN}"
+    bot_token = os.getenv("BOT_TOKEN")
+    if bot_token:
+        headers["Authorization"] = f"Bearer {bot_token}"
+    print("[send_results] Sending headers:", headers)
     try:
         resp = requests.post(url, json=payload, headers=headers, timeout=10)
         resp.raise_for_status()


### PR DESCRIPTION
## Summary
- read BOT_TOKEN inside send_results instead of at import
- log the headers before posting results

## Testing
- `pytest -q`
- `node --test tests/test_id_validation.js`


------
https://chatgpt.com/codex/tasks/task_e_687e5d00e024832ea0b4a4a643aaeab9