### PR TITLE
Add boto3 and warn when S3 client missing

### DIFF
--- a/bot_service/requirements.txt
+++ b/bot_service/requirements.txt
@@ -11,5 +11,6 @@ openai>=1.0.0
 pdfkit
 jinja2
 python-dotenv
+boto3
 
 

--- a/bot_service/services/storage_service.py
+++ b/bot_service/services/storage_service.py
@@ -36,6 +36,8 @@ def upload_file(local_path: str, key: str) -> str:
     Returns the URL to the uploaded file or the local file path when saved
     to disk.
     """
+    if BUCKET and not _s3_client:
+        logger.warning("S3 upload skipped: boto3 not available or AWS credentials not set")
     if BUCKET and _s3_client:
         try:
             _s3_client.upload_file(local_path, BUCKET, key)


### PR DESCRIPTION
## Summary
- include boto3 in the bot service requirements
- log a warning when S3 uploads are skipped because boto3 or credentials are not available

## Testing
- `pytest -q`
- `node --test tests/test_id_validation.js`


------
https://chatgpt.com/codex/tasks/task_e_687e6407e818832ebdafcb6dc5bea244