### PR TITLE
Add verbose logging around S3 uploads

### DIFF
--- a/bot_service/main.py
+++ b/bot_service/main.py
@@ -88,6 +88,7 @@ def process():
                 for pdf in letter_dir.glob("*.pdf"):
                     key = f"letters/{client_id}/{pdf.name}"
                     url = upload_file(str(pdf), key)
+                    logger.info("Uploaded letter %s -> %s", key, url)
                     letters.append({"name": pdf.name, "url": url})
 
                 logger.info("Generated %d letters", len(letters))
@@ -102,6 +103,7 @@ def process():
             logger.info("Generated fallback letter PDF at %s", letter_path)
             key = f"letters/{client_id}/dispute_letter.pdf"
             url = upload_file(letter_path, key)
+            logger.info("Uploaded letter %s -> %s", key, url)
             letters = [{"name": "dispute_letter.pdf", "url": url}]
 
         send_results(client_id, letters)


### PR DESCRIPTION
## Summary
- add initialization logs for S3 client
- emit detailed info in `upload_file` about S3 configuration
- log when files are uploaded or fall back to local storage
- log returned URL when calling `upload_file`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6802baf4832eb4de20b4e4b25f11