### PR TITLE
Fix bot env loading and S3 logging

### DIFF
--- a/bot_service/main.py
+++ b/bot_service/main.py
@@ -1,4 +1,11 @@
 import os
+from dotenv import load_dotenv
+
+# Load environment variables from the service's .env file explicitly before any
+# other imports use them. This ensures modules like `storage_service` see the
+# correct values even when the working directory differs.
+load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), ".env"))
+
 import tempfile
 import requests
 from pathlib import Path
@@ -15,13 +22,10 @@ from logic import (
     instructions_generator,
 )
 from config.settings import BOT_PORT
-from dotenv import load_dotenv
 import logging
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
-
-load_dotenv()
 
 app = Flask(__name__)
 

--- a/bot_service/services/storage_service.py
+++ b/bot_service/services/storage_service.py
@@ -4,6 +4,8 @@ import logging
 from pathlib import Path
 from config.settings import BACKEND_URL
 
+logger = logging.getLogger(__name__)
+
 try:
     import boto3
     from botocore.exceptions import BotoCoreError, ClientError
@@ -13,6 +15,16 @@ except ImportError:  # Allow running without boto3 when not using S3
 
 BUCKET = os.getenv("AWS_S3_BUCKET")
 REGION = os.getenv("AWS_REGION", "us-east-1")
+access_key_preview = (os.getenv("AWS_ACCESS_KEY_ID") or "")[:4]
+secret_key_preview = (os.getenv("AWS_SECRET_ACCESS_KEY") or "")[:4]
+
+logger.info(
+    "Storage env BUCKET=%s REGION=%s ACCESS_KEY=%s**** SECRET_KEY=%s****",
+    BUCKET,
+    REGION,
+    access_key_preview,
+    secret_key_preview,
+)
 
 # Store files under the backend uploads directory so the Node backend can
 # serve them from the same location as credit reports.
@@ -36,8 +48,6 @@ if BUCKET and boto3:
 else:
     reason = "no bucket configured" if not BUCKET else "boto3 unavailable"
     logging.getLogger(__name__).info("S3 client not initialized: %s", reason)
-
-logger = logging.getLogger(__name__)
 
 
 def upload_file(local_path: str, key: str) -> str:


### PR DESCRIPTION
## Summary
- load bot `.env` explicitly before other imports
- log AWS environment values when initializing storage service

## Testing
- `pytest -q`
- `node tests/test_id_validation.js`

------
https://chatgpt.com/codex/tasks/task_e_687e72bec4a8832e9883fbc3ea7ed2ea