### PR TITLE
Implement signed S3 access

### DIFF
--- a/backend/models/Customer.js
+++ b/backend/models/Customer.js
@@ -22,7 +22,7 @@ const CustomerSchema = new mongoose.Schema({
   letters: [
     {
       name: String,
-      url: String
+      key: String
     }
   ]
 });

--- a/backend/routes/bot.js
+++ b/backend/routes/bot.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const Customer = require('../models/Customer');
 const authMiddleware = require('../middleware/auth');
 const botAuth = require('../middleware/authBot');
+const { getSignedUrl } = require('../utils/files');
 
 function getMode(req) {
   const value =
@@ -38,7 +39,7 @@ const updateStatus = async (req, res) => {
     if (status === 'In Progress') {
       const payload = {
         clientId: customer._id,
-        creditReportUrl: customer.creditReport,
+        creditReportUrl: getSignedUrl(customer.creditReport, req),
         customerName: customer.customerName,
         phone: customer.phone,
         email: customer.email,

--- a/backend/routes/customers.js
+++ b/backend/routes/customers.js
@@ -140,20 +140,40 @@ router.delete('/:id', async (req, res) => {
     if (!customer) return res.status(404).json({ error: 'Customer not found' });
 
     if (customer.creditReport) {
-      const url = customer.creditReport;
-      if (process.env.AWS_S3_BUCKET && url.includes('amazonaws.com')) {
+      const key = customer.creditReport;
+      if (process.env.AWS_S3_BUCKET) {
         const s3 = new AWS.S3({
           region: process.env.AWS_REGION,
           accessKeyId: process.env.AWS_ACCESS_KEY_ID,
           secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
         });
-        const key = new URL(url).pathname.slice(1);
         await s3.deleteObject({ Bucket: process.env.AWS_S3_BUCKET, Key: key }).promise();
       } else {
-        const relative = url.replace(/^.*\/uploads\//, '');
-        const localPath = path.join('uploads', relative);
+        const localPath = path.join('uploads', key);
         if (fs.existsSync(localPath)) fs.unlinkSync(localPath);
 
+      }
+    }
+
+    if (Array.isArray(customer.letters)) {
+      for (const letter of customer.letters) {
+        const lkey = letter.key;
+        if (!lkey) continue;
+        if (process.env.AWS_S3_BUCKET) {
+          const s3 = new AWS.S3({
+            region: process.env.AWS_REGION,
+            accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+          });
+          try {
+            await s3.deleteObject({ Bucket: process.env.AWS_S3_BUCKET, Key: lkey }).promise();
+          } catch (e) {
+            console.error('Failed to delete letter', lkey, e.message);
+          }
+        } else {
+          const lp = path.join('uploads', lkey);
+          if (fs.existsSync(lp)) fs.unlinkSync(lp);
+        }
       }
     }
 

--- a/backend/routes/files.js
+++ b/backend/routes/files.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const AWS = require('aws-sdk');
+const fs = require('fs');
+const path = require('path');
+const router = express.Router();
+
+const auth = require('../middleware/auth');
+
+const s3 = process.env.AWS_S3_BUCKET
+  ? new AWS.S3({
+      region: process.env.AWS_REGION,
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    })
+  : null;
+
+router.use(auth);
+
+router.get('/get-signed-url', (req, res) => {
+  const key = req.query.key;
+  if (!key) return res.status(400).json({ error: 'Missing key' });
+
+  if (s3) {
+    const url = s3.getSignedUrl('getObject', {
+      Bucket: process.env.AWS_S3_BUCKET,
+      Key: key,
+      Expires: 300, // 5 minutes
+    });
+    return res.json({ url });
+  }
+
+  const url = `${req.protocol}://${req.get('host')}/uploads/${key}`;
+  res.json({ url });
+});
+
+router.delete('/delete', async (req, res) => {
+  const key = req.query.key;
+  if (!key) return res.status(400).json({ error: 'Missing key' });
+
+  try {
+    if (s3) {
+      await s3
+        .deleteObject({ Bucket: process.env.AWS_S3_BUCKET, Key: key })
+        .promise();
+    } else {
+      const filePath = path.join('uploads', key);
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    }
+    res.json({ message: 'File deleted' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Delete failed' });
+  }
+});
+
+module.exports = router;

--- a/backend/utils/files.js
+++ b/backend/utils/files.js
@@ -1,0 +1,38 @@
+const AWS = require('aws-sdk');
+const fs = require('fs');
+const path = require('path');
+
+const s3 = process.env.AWS_S3_BUCKET
+  ? new AWS.S3({
+      region: process.env.AWS_REGION,
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    })
+  : null;
+
+function getSignedUrl(key, req) {
+  if (s3) {
+    return s3.getSignedUrl('getObject', {
+      Bucket: process.env.AWS_S3_BUCKET,
+      Key: key,
+      Expires: 300,
+    });
+  }
+  const base = req
+    ? `${req.protocol}://${req.get('host')}`
+    : process.env.BACKEND_URL || `http://localhost:${process.env.PORT || 5000}`;
+  return `${base}/uploads/${key}`;
+}
+
+async function deleteFile(key) {
+  if (s3) {
+    await s3
+      .deleteObject({ Bucket: process.env.AWS_S3_BUCKET, Key: key })
+      .promise();
+  } else {
+    const filePath = path.join('uploads', key);
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  }
+}
+
+module.exports = { getSignedUrl, deleteFile };

--- a/bot_service/main.py
+++ b/bot_service/main.py
@@ -28,13 +28,6 @@ import logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 
-<<<<<<< HEAD
-=======
-# טעינת משתני סביבה
-load_dotenv()
-
-# יצירת אינסטנס של Flask
->>>>>>> 3d4cd18 (WIP: local changes before pulling)
 app = Flask(__name__)
 
 def create_sample_letter(text: str, output_path: str):
@@ -102,9 +95,9 @@ def process():
 
                 for pdf in letter_dir.glob("*.pdf"):
                     key = f"letters/{client_id}/{pdf.name}"
-                    url = upload_file(str(pdf), key)
-                    logger.info("Uploaded letter %s -> %s", key, url)
-                    letters.append({"name": pdf.name, "url": url})
+                    upload_file(str(pdf), key)
+                    logger.info("Uploaded letter %s", key)
+                    letters.append({"name": pdf.name, "key": key})
 
                 logger.info("Generated %d letters", len(letters))
             except Exception as e:
@@ -117,9 +110,9 @@ def process():
                 letter_path = f.name
             logger.info("Generated fallback letter PDF at %s", letter_path)
             key = f"letters/{client_id}/dispute_letter.pdf"
-            url = upload_file(letter_path, key)
-            logger.info("Uploaded letter %s -> %s", key, url)
-            letters = [{"name": "dispute_letter.pdf", "url": url}]
+            upload_file(letter_path, key)
+            logger.info("Uploaded letter %s", key)
+            letters = [{"name": "dispute_letter.pdf", "key": key}]
 
         send_results(client_id, letters)
         logger.info("Results sent to backend")

--- a/bot_service/services/storage_service.py
+++ b/bot_service/services/storage_service.py
@@ -53,8 +53,7 @@ else:
 def upload_file(local_path: str, key: str) -> str:
     """Upload a file to S3 if configured or save locally.
 
-    Returns the URL to the uploaded file or the local file path when saved
-    to disk.
+    Returns the storage key for the uploaded file.
     """
     logger.info(
         "[upload_file] BUCKET=%s REGION=%s _s3_client=%s ACCESS_KEY=%s****",
@@ -72,9 +71,8 @@ def upload_file(local_path: str, key: str) -> str:
     if BUCKET and _s3_client:
         try:
             _s3_client.upload_file(local_path, BUCKET, key)
-            url = f"https://{BUCKET}.s3.{REGION}.amazonaws.com/{key}"
             logger.info("Uploaded %s to S3 bucket %s", key, BUCKET)
-            return url
+            return key
         except (BotoCoreError, ClientError) as e:
             raise RuntimeError(f"Failed to upload {key}: {e}")
 
@@ -83,4 +81,4 @@ def upload_file(local_path: str, key: str) -> str:
     dest_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(local_path, dest_path)
     logger.warning("Saved %s locally at %s (S3 upload skipped)", key, dest_path)
-    return f"{BACKEND_URL}/uploads/{key}"
+    return key

--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -11,6 +11,7 @@ import ConfirmDialog from '../components/ConfirmDialog';
 import { AppModeContext } from '../ModeContext';
 import { AuthContext } from '../AuthContext';
 import { CustomersContext } from '../CustomersContext';
+import { getSignedUrl } from '../utils';
 
 const formColumns = [
   { field: 'customerName', headerName: 'Customer Name', width: 150, editable: true },
@@ -150,7 +151,7 @@ export default function Customers() {
       .then((data) => {
         setRows((prev) =>
           prev.map((row) =>
-            row.id === uploadId ? { ...row, creditReport: data.url } : row
+            row.id === uploadId ? { ...row, creditReport: data.key } : row
           )
         );
         setSnackbar('Credit report uploaded successfully ✅');
@@ -225,22 +226,25 @@ export default function Customers() {
     width: 220,
     editable: true,
     renderCell: (params) => {
-      const url = params.value;
-      if (!url || params.row.status === 'Needs Updated Report') {
+      const key = params.value;
+      if (!key || params.row.status === 'Needs Updated Report') {
         return (
           <span style={{ color: 'red' }}>Upload a new report to start the next round</span>
         );
       }
-      const fullUrl = url.startsWith('http') ? url : `${BACKEND_URL}${url.startsWith('/') ? '' : '/'}` + url;
       return (
         <div style={{ display: 'flex', gap: 8 }}>
           <Button
             variant="text"
             size="small"
-            component="a"
-            href={fullUrl}
-            target="_blank"
-            rel="noopener noreferrer"
+            onClick={async () => {
+              try {
+                const url = await getSignedUrl(key, authHeaders, BACKEND_URL);
+                window.open(url, '_blank');
+              } catch {
+                setSnackbar('Failed to get link');
+              }
+            }}
           >
             View Report
           </Button>

--- a/credit-dashboard/src/pages/WorkToday.js
+++ b/credit-dashboard/src/pages/WorkToday.js
@@ -3,11 +3,12 @@ import { DataGrid } from '@mui/x-data-grid';
 import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Chip from '@mui/material/Chip';
+import Button from '@mui/material/Button';
 import { AuthContext } from '../AuthContext';
+import { getSignedUrl } from '../utils';
 
 
-
-const columns = [
+const BASE_COLUMNS = [
   { field: 'customerName', headerName: 'Customer Name', width: 150 },
   { field: 'phone', headerName: 'Phone', width: 130 },
   { field: 'email', headerName: 'Email', width: 180 },
@@ -23,14 +24,7 @@ const columns = [
       <a href={params.value} target="_blank" rel="noopener noreferrer">Open</a>
     ),
   },
-  {
-    field: 'creditReport',
-    headerName: 'Credit Report Link',
-    width: 180,
-    renderCell: (params) => (
-      <a href={params.value} target="_blank" rel="noopener noreferrer">Report</a>
-    ),
-  },
+  // creditReport column added in component
   { field: 'smartCreditInfo', headerName: 'SmartCredit Login Info', width: 180 },
   {
     field: 'fullFile',
@@ -54,6 +48,31 @@ export default function WorkToday() {
   const API_URL = `${BACKEND_URL}/api/customers/today`;
   const { token, logout } = React.useContext(AuthContext);
   const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
+
+  const columns = React.useMemo(() => [
+    ...BASE_COLUMNS,
+    {
+      field: 'creditReport',
+      headerName: 'Credit Report Link',
+      width: 180,
+      renderCell: (params) => (
+        <Button
+          variant="text"
+          size="small"
+          onClick={async () => {
+            try {
+              const url = await getSignedUrl(params.value, authHeaders, BACKEND_URL);
+              window.open(url, '_blank');
+            } catch {
+              console.error('Failed to get link');
+            }
+          }}
+        >
+          Report
+        </Button>
+      ),
+    },
+  ], [authHeaders, BACKEND_URL]);
 
   const checkAuth = (res) => {
     if (res.status === 401) {

--- a/credit-dashboard/src/utils.js
+++ b/credit-dashboard/src/utils.js
@@ -1,0 +1,8 @@
+export async function getSignedUrl(key, authHeaders = {}, backendUrl = '') {
+  const res = await fetch(`${backendUrl}/api/files/get-signed-url?key=${encodeURIComponent(key)}`, {
+    headers: authHeaders,
+  });
+  if (!res.ok) throw new Error('Failed to get URL');
+  const data = await res.json();
+  return data.url;
+}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,7 +55,7 @@ def test_process_testing_mode(monkeypatch, tmp_path):
     uploaded = {}
     def fake_upload(local, key):
         uploaded[key] = True
-        return f'url/{key}'
+        return key
     monkeypatch.setattr(bot_main, 'upload_file', fake_upload)
 
     results = {}
@@ -71,6 +71,7 @@ def test_process_testing_mode(monkeypatch, tmp_path):
     assert results['cid'] == 'c1'
     assert results['letters']
     assert results['letters'][0]['name'].endswith('.pdf')
+    assert results['letters'][0]['key']
 
 
 def test_process_real_mode_fallback(monkeypatch, tmp_path):
@@ -83,7 +84,7 @@ def test_process_real_mode_fallback(monkeypatch, tmp_path):
     uploaded = {}
     def fake_upload(local, key):
         uploaded[key] = True
-        return f'url/{key}'
+        return key
     monkeypatch.setattr(bot_main, 'upload_file', fake_upload)
 
     results = {}


### PR DESCRIPTION
## Summary
- store only S3 object keys in Mongo
- generate presigned URLs via new `/api/files` routes
- delete S3 objects using stored keys
- update bot service and frontend to use keys
- add helper for requesting signed URLs

## Testing
- `node --test tests/test_id_validation.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9b55ae4c832e8b553aff81bc564b