### PR TITLE
Handle invalid signed URL keys

### DIFF
--- a/credit-dashboard/src/pages/Customers.js
+++ b/credit-dashboard/src/pages/Customers.js
@@ -238,6 +238,11 @@ export default function Customers() {
             variant="text"
             size="small"
             onClick={async () => {
+              if (!key || key === 'undefined') {
+                console.warn('Invalid credit report key', key);
+                setSnackbar('Invalid report link');
+                return;
+              }
               try {
                 const url = await getSignedUrl(key, authHeaders, BACKEND_URL);
                 window.open(url, '_blank');

--- a/credit-dashboard/src/pages/SendLetters.js
+++ b/credit-dashboard/src/pages/SendLetters.js
@@ -26,6 +26,10 @@ function createColumns(authHeaders, backendUrl) {
               variant="outlined"
               size="small"
               onClick={async () => {
+                if (!l.key || l.key === 'undefined') {
+                  console.warn('Invalid letter key', l.key);
+                  return;
+                }
                 try {
                   const url = await getSignedUrl(l.key, authHeaders, backendUrl);
                   window.open(url, '_blank');

--- a/credit-dashboard/src/utils.js
+++ b/credit-dashboard/src/utils.js
@@ -1,7 +1,13 @@
 export async function getSignedUrl(key, authHeaders = {}, backendUrl = '') {
-  const res = await fetch(`${backendUrl}/api/files/get-signed-url?key=${encodeURIComponent(key)}`, {
-    headers: authHeaders,
-  });
+  if (!key || key === 'undefined') {
+    throw new Error('Invalid key');
+  }
+  const res = await fetch(
+    `${backendUrl}/api/files/get-signed-url?key=${encodeURIComponent(key)}`,
+    {
+      headers: authHeaders,
+    }
+  );
   if (!res.ok) throw new Error('Failed to get URL');
   const data = await res.json();
   return data.url;

--- a/tests/getSignedUrl.test.mjs
+++ b/tests/getSignedUrl.test.mjs
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getSignedUrl } from '../credit-dashboard/src/utils.js';
+
+test('getSignedUrl rejects empty key without fetch', async () => {
+  let called = false;
+  const original = global.fetch;
+  global.fetch = () => { called = true; throw new Error('fetch called'); };
+  await assert.rejects(() => getSignedUrl('', {}, ''), /Invalid key/);
+  assert.strictEqual(called, false);
+  global.fetch = original;
+});
+
+test('getSignedUrl rejects "undefined" string without fetch', async () => {
+  let called = false;
+  const original = global.fetch;
+  global.fetch = () => { called = true; throw new Error('fetch called'); };
+  await assert.rejects(() => getSignedUrl('undefined', {}, ''), /Invalid key/);
+  assert.strictEqual(called, false);
+  global.fetch = original;
+});


### PR DESCRIPTION
## Summary
- validate keys passed to `getSignedUrl`
- guard against invalid keys in **SendLetters** and **Customers** pages
- test `getSignedUrl` rejects invalid keys

## Testing
- `node --test tests/test_id_validation.js tests/getSignedUrl.test.mjs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea48cd85c832eb9c765f8c961f2b6