### PR TITLE
Handle URL keys in file signing

### DIFF
--- a/backend/routes/files.js
+++ b/backend/routes/files.js
@@ -18,7 +18,13 @@ router.use(auth);
 
 router.get('/get-signed-url', (req, res) => {
   const key = req.query.key;
-  if (!key) return res.status(400).json({ error: 'Missing key' });
+  if (!key || key === 'undefined')
+    return res.status(400).json({ error: 'Invalid key' });
+
+  if (/^https?:\/\//i.test(key)) {
+    // Already a full URL, return as-is without signing
+    return res.json({ url: key });
+  }
 
   if (s3) {
     const url = s3.getSignedUrl('getObject', {

--- a/tests/test_files.js
+++ b/tests/test_files.js
@@ -1,0 +1,53 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const express = require('../backend/node_modules/express');
+const path = require('path');
+
+function withRouter(handler) {
+  const authPath = path.resolve(__dirname, '../backend/middleware/auth.js');
+  const cachedAuth = require.cache[authPath];
+  require.cache[authPath] = { exports: (req, res, next) => next() };
+
+  const router = require('../backend/routes/files');
+  const app = express();
+  app.use('/', router);
+
+  return handler(app).finally(() => {
+    if (cachedAuth) {
+      require.cache[authPath] = cachedAuth;
+    } else {
+      delete require.cache[authPath];
+    }
+    delete require.cache[require.resolve('../backend/routes/files')];
+  });
+}
+
+function requestJson(app, method, path) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address();
+      fetch(`http://localhost:${port}${path}`, { method })
+        .then(async (res) => {
+          const body = await res.json().catch(() => ({}));
+          server.close();
+          resolve({ status: res.status, body });
+        })
+        .catch((err) => { server.close(); reject(err); });
+    });
+  });
+}
+
+test('returns full URL unchanged', async () => {
+  await withRouter(async (app) => {
+    const { status, body } = await requestJson(app, 'GET', '/get-signed-url?key=http://example.com/x.pdf');
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.url, 'http://example.com/x.pdf');
+  });
+});
+
+test('rejects literal "undefined"', async () => {
+  await withRouter(async (app) => {
+    const { status } = await requestJson(app, 'GET', '/get-signed-url?key=undefined');
+    assert.strictEqual(status, 400);
+  });
+});


### PR DESCRIPTION
## Summary
- improve `/get-signed-url` to detect full URLs and invalid keys
- add regression tests for files router

## Testing
- `OPENAI_API_KEY=dummy pytest -q`
- `node --test tests/test_id_validation.js tests/test_files.js` *(fails: `node` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea48e5e40832ebd4538327ffe2955