### PR TITLE
Prevent double signing of S3 URLs

### DIFF
--- a/backend/utils/files.js
+++ b/backend/utils/files.js
@@ -11,6 +11,8 @@ const s3 = process.env.AWS_S3_BUCKET
   : null;
 
 function getSignedUrl(key, req) {
+  if (/^https?:\/\//i.test(key)) return key;
+
   if (s3) {
     return s3.getSignedUrl('getObject', {
       Bucket: process.env.AWS_S3_BUCKET,


### PR DESCRIPTION
## Summary
- ensure `getSignedUrl` returns provided URL unchanged when already a full URL

## Testing
- `node --test tests/test_files.js tests/getSignedUrl.test.mjs tests/test_id_validation.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eaa0ee180832e9bc81736931b4f73