### PR TITLE
Add cron locking and README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ values for your setup.
 - `JWT_SECRET` — secret key for signing JSON Web Tokens
 - `ADMIN_USER` — default admin username
 - `ADMIN_PASS_HASH` — scrypt hash of the admin password in the form `salt$hash`
-- `ENABLE_CRON` — set to `true` to run the optional scheduled job
+- `ENABLE_CRON` — set to `true` to run the optional scheduled job. Enable this on only one backend instance or use a locking mechanism to avoid duplicate runs.
 
 ### Bot
 

--- a/backend/utils/cronLock.js
+++ b/backend/utils/cronLock.js
@@ -1,0 +1,32 @@
+const mongoose = require('mongoose');
+
+const CronLockSchema = new mongoose.Schema({
+  name: { type: String, unique: true },
+  lockedUntil: Date
+});
+
+const CronLock = mongoose.models.CronLock || mongoose.model('CronLock', CronLockSchema);
+
+async function acquireLock(ttlMs = 5 * 60 * 1000) {
+  const now = new Date();
+  try {
+    const lock = await CronLock.findOneAndUpdate(
+      { name: 'cron', $or: [{ lockedUntil: { $exists: false } }, { lockedUntil: { $lte: now } }] },
+      { name: 'cron', lockedUntil: new Date(now.getTime() + ttlMs) },
+      { new: true, upsert: true }
+    ).exec();
+    return !!lock;
+  } catch (err) {
+    if (err.code === 11000) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+async function releaseLock() {
+  await CronLock.deleteOne({ name: 'cron' }).catch(() => {});
+}
+
+module.exports = { acquireLock, releaseLock };
+


### PR DESCRIPTION
## Summary
- warn in README that ENABLE_CRON should be enabled only once
- add cronLock helper using MongoDB
- skip cron job when lock is active and release it after run

## Testing
- `node --test tests/test_files.js tests/test_id_validation.js tests/getSignedUrl.test.mjs`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fc2370fcc832e88d92019a96c7600