### PR TITLE
Install wkhtmltopdf in bot image

### DIFF
--- a/bot_service/Dockerfile
+++ b/bot_service/Dockerfile
@@ -1,9 +1,22 @@
 FROM python:3.10-slim
+
 WORKDIR /app
+
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+
+# Install wkhtmltopdf for pdfkit
+RUN apt-get update \
+    && apt-get install -y wkhtmltopdf \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt ./
+
 RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . .
+
 ENV PORT=6000
+
 CMD ["sh", "-c", "gunicorn -b 0.0.0.0:$PORT main:app"]


### PR DESCRIPTION
## Summary
- install `wkhtmltopdf` inside the bot service container

## Testing
- `pytest -q`
- `npm test --prefix backend` *(fails: no test specified)*
- `CI=true npm test --prefix credit-dashboard --silent` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_687fc2382da8832eb2f3b975ceec44e1