### PR TITLE
Validate file keys

### DIFF
--- a/backend/routes/files.js
+++ b/backend/routes/files.js
@@ -18,7 +18,12 @@ router.use(auth);
 
 router.get('/get-signed-url', (req, res) => {
   const key = req.query.key;
-  if (!key || key === 'undefined')
+  if (
+    !key ||
+    key === 'undefined' ||
+    key.includes('..') ||
+    path.isAbsolute(key)
+  )
     return res.status(400).json({ error: 'Invalid key' });
 
   if (/^https?:\/\//i.test(key)) {
@@ -42,6 +47,8 @@ router.get('/get-signed-url', (req, res) => {
 router.delete('/delete', async (req, res) => {
   const key = req.query.key;
   if (!key) return res.status(400).json({ error: 'Missing key' });
+  if (key.includes('..') || path.isAbsolute(key))
+    return res.status(400).json({ error: 'Invalid key' });
 
   try {
     if (s3) {

--- a/tests/test_files.js
+++ b/tests/test_files.js
@@ -51,3 +51,10 @@ test('rejects literal "undefined"', async () => {
     assert.strictEqual(status, 400);
   });
 });
+
+test('rejects suspicious key', async () => {
+  await withRouter(async (app) => {
+    const { status } = await requestJson(app, 'DELETE', '/delete?key=../secret');
+    assert.strictEqual(status, 400);
+  });
+});


### PR DESCRIPTION
## Summary
- validate file key for absolute/relative paths in files router
- test suspicious delete request path

## Testing
- `node --test tests/test_files.js tests/test_id_validation.js tests/getSignedUrl.test.mjs`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fc239d964832e8ac789c33a63b1cb