### PR TITLE
Explain local storage requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ docker-compose up --build
 Edit the environment variables in the compose file if you need to adjust
 connections or credentials.
 
+When running the stack without Amazon S3 you must make sure that the
+`backend/uploads` directory is shared between the backend and bot service so
+that uploaded files are accessible to both containers. Either configure the AWS
+S3 variables in `.env` or mount the folder as a volume as shown in the compose
+file.
+
 ## ✅ Testing
 
 - Make sure all three servers run without errors.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
 
   backend:
     build: ./backend
+    # Share local uploads with the bot service when not using S3
+    volumes:
+      - ./backend/uploads:/app/uploads
     environment:
       MONGO_URI: ${MONGO_URI}
       PORT: ${PORT}
@@ -33,6 +36,8 @@ services:
 
   bot:
     build: ./bot_service
+    volumes:
+      - ./backend/uploads:/app/backend/uploads
     environment:
       PORT: ${PORT_BOT:-6000}
       BACKEND_URL: ${BACKEND_URL}


### PR DESCRIPTION
## Summary
- clarify that S3 must be configured when using Docker Compose, otherwise backend/uploads must be shared
- share `backend/uploads` volume with backend and bot services in docker-compose

## Testing
- `node --test tests/getSignedUrl.test.mjs`
- `node --test tests/test_files.js`
- `node --test tests/test_id_validation.js`
- `pytest -q tests/test_main.py tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_687fc23a9834832e847d1a1f89988e2f