### PR TITLE
Update env hints for container deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,9 @@ ADMIN_PASS_HASH=your-salt$your-scrypt-hash
 ENABLE_CRON=false
 
 # === Bot Service ===
-BACKEND_URL=http://localhost:5000
-BOT_PROCESS_URL=http://localhost:6000/api/bot/process
-BOT_START_URL=http://localhost:6000/start
+BACKEND_URL=http://localhost:5000 # use http://backend:5000 inside containers
+BOT_PROCESS_URL=http://localhost:6000/api/bot/process # use http://bot:6000/api/bot/process in containers
+BOT_START_URL=http://localhost:6000/start # use http://bot:6000/start in containers
 BOT_TOKEN=your-bot-token
 
 # === AWS S3 ===

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ connections or credentials.
 2. **Create an ECS service or Elastic Beanstalk environment** using the pushed
    images. Set the same environment variables shown in `docker-compose.yml`.
    MongoDB can be provided by an Atlas cluster or a self‑hosted container.
+   When running containers, use internal URLs such as `http://backend:5000` for
+   `BACKEND_URL` and `http://bot:6000` for the bot service endpoints.
 
 3. **Deploy updates** by rebuilding the images, pushing them to ECR and
    redeploying the service.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,7 @@
 MONGO_URI=mongodb://localhost:27017/creditdb
 PORT=5000
-BOT_PROCESS_URL=http://localhost:6000/api/bot/process
-BOT_START_URL=http://localhost:6000/start
+BOT_PROCESS_URL=http://localhost:6000/api/bot/process # use http://bot:6000/api/bot/process in containers
+BOT_START_URL=http://localhost:6000/start # use http://bot:6000/start in containers
 APP_MODE=testing
 AWS_REGION=us-east-1
 AWS_S3_BUCKET=your-bucket-name

--- a/bot_service/.env.example
+++ b/bot_service/.env.example
@@ -1,5 +1,5 @@
 PORT=6000
-BACKEND_URL=http://localhost:5000
+BACKEND_URL=http://localhost:5000 # use http://backend:5000 inside containers
 BOT_TOKEN=
 AWS_REGION=us-east-1
 AWS_S3_BUCKET=your-bucket-name


### PR DESCRIPTION
## Summary
- document container internal URLs in `.env.example`
- note container-friendly values in backend and bot env templates
- clarify README deployment notes

## Testing
- `node --test tests/getSignedUrl.test.mjs`
- `node --test tests/test_files.js`
- `pytest -q tests/test_utils.py tests/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_687fc23b6218832ea4bde645cf9b896c