### PR TITLE
Use BOT_START_URL to wake bot service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ ENABLE_CRON=false
 # === Bot Service ===
 BACKEND_URL=http://localhost:5000 # use http://backend:5000 inside containers
 BOT_PROCESS_URL=http://localhost:6000/api/bot/process # use http://bot:6000/api/bot/process in containers
-BOT_START_URL=http://localhost:6000/start # use http://bot:6000/start in containers
+BOT_START_URL=http://localhost:6000/start # optional wake-up URL, use http://bot:6000/start in containers
 BOT_TOKEN=your-bot-token
 
 # === AWS S3 ===

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ values for your setup.
 - `PORT` — port for the Node server (default 5000)
 - `ALLOWED_ORIGIN` — origin allowed for CORS requests
 - `BOT_PROCESS_URL` — bot endpoint for processing requests
-- `BOT_START_URL` — endpoint to start or ping the bot service
+- `BOT_START_URL` — optional URL the backend pings on startup to wake the bot
 - `APP_MODE` — "real" or "testing" to control how the bot generates letters
 - `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` — storage credentials
 - `JWT_SECRET` — secret key for signing JSON Web Tokens

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,7 @@
 MONGO_URI=mongodb://localhost:27017/creditdb
 PORT=5000
 BOT_PROCESS_URL=http://localhost:6000/api/bot/process # use http://bot:6000/api/bot/process in containers
-BOT_START_URL=http://localhost:6000/start # use http://bot:6000/start in containers
+BOT_START_URL=http://localhost:6000/start # optional wake-up URL, use http://bot:6000/start in containers
 APP_MODE=testing
 AWS_REGION=us-east-1
 AWS_S3_BUCKET=your-bucket-name

--- a/backend/server.js
+++ b/backend/server.js
@@ -44,6 +44,19 @@ async function start() {
       logger.info('MongoDB connected');
       app.listen(PORT, () => {
         logger.info('Server running', { url: `http://localhost:${PORT}` });
+        if (process.env.BOT_START_URL) {
+          axios
+            .get(process.env.BOT_START_URL)
+            .then(() => {
+              logger.info('Pinged bot service', { url: process.env.BOT_START_URL });
+            })
+            .catch((err) => {
+              logger.warn('Failed to ping bot service', {
+                url: process.env.BOT_START_URL,
+                error: err.message,
+              });
+            });
+        }
       });
     })
     .catch((err) => logger.error('Mongo connection error', { error: err.message }));


### PR DESCRIPTION
## Summary
- ping bot service on server start
- document BOT_START_URL as optional wake-up URL

## Testing
- `node --test tests/test_files.js tests/getSignedUrl.test.mjs tests/test_id_validation.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd9b92edc832eb16cd1fb790a7055